### PR TITLE
Refactor skins module structure

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,6 +1,6 @@
 import express from "express";
 import cors from "cors";
-import { createSkinsRouter } from "./modules/skins/router";
+import { createSkinsRouter } from "./modules/skins";
 import { getPriceUSD } from "./modules/steam/repo";
 
 /**

--- a/server/src/modules/skins/index.ts
+++ b/server/src/modules/skins/index.ts
@@ -1,0 +1,1 @@
+export { createSkinsRouter } from "./router";

--- a/server/src/modules/skins/service.ts
+++ b/server/src/modules/skins/service.ts
@@ -1,0 +1,32 @@
+import { RARITY_TO_TAG, searchByRarity } from "../steam/repo";
+import { type Exterior } from "./types";
+
+/** Supported rarities extracted from Steam mapping. */
+export const ALL_RARITIES = Object.keys(RARITY_TO_TAG) as (keyof typeof RARITY_TO_TAG)[];
+
+/** Extracts exterior from a market_hash_name, defaults to Field-Tested. */
+export const parseMarketHashExterior = (marketHashName: string): Exterior => {
+  const match = marketHashName.match(/\((Factory New|Minimal Wear|Field-Tested|Well-Worn|Battle-Scarred)\)$/i);
+  return (match?.[1] as Exterior) ?? "Field-Tested";
+};
+
+/** Removes exterior suffix, returning the base item name. */
+export const baseFromMarketHash = (marketHashName: string): string =>
+  marketHashName.replace(/ \((Factory New|Minimal Wear|Field-Tested|Well-Worn|Battle-Scarred)\)$/i, "");
+
+/**
+ * Fetches total_count for each rarity with minimal requests.
+ */
+export const getTotals = async (
+  rarities: (keyof typeof RARITY_TO_TAG)[],
+  normalOnly: boolean,
+): Promise<{ perRarity: Record<string, number>; sum: number }> => {
+  const perRarity: Record<string, number> = {};
+  let sum = 0;
+  for (const rarity of rarities) {
+    const { total } = await searchByRarity({ rarity, start: 0, count: 1, normalOnly });
+    perRarity[rarity] = total;
+    sum += total;
+  }
+  return { perRarity, sum };
+};

--- a/server/src/modules/skins/types.ts
+++ b/server/src/modules/skins/types.ts
@@ -1,0 +1,29 @@
+/** List of supported exterior values in predefined order. */
+export const EXTERIORS = [
+  "Factory New",
+  "Minimal Wear",
+  "Field-Tested",
+  "Well-Worn",
+  "Battle-Scarred",
+] as const;
+
+/** Exterior type extracted from a market hash name. */
+export type Exterior = typeof EXTERIORS[number];
+
+/** Modes for expanding missing exteriors in the response. */
+export type ExpandMode = "none" | "price" | "all";
+
+/** Details about a particular exterior variant of a skin. */
+export interface SkinExterior {
+  exterior: Exterior;
+  marketHashName: string;
+  sell_listings: number;
+  price: number | null;
+}
+
+/** Aggregated group of skins by base name and rarity. */
+export interface SkinsGroup {
+  baseName: string;
+  rarity: string;
+  exteriors: SkinExterior[];
+}

--- a/server/src/modules/skins/validators.ts
+++ b/server/src/modules/skins/validators.ts
@@ -1,0 +1,7 @@
+/** Boolean parser for query parameters with a default fallback. */
+export const parseBoolean = (value: unknown, defaultValue = false): boolean => {
+  const text = String(value ?? "");
+  if (/^(1|true|yes|on)$/i.test(text)) return true;
+  if (/^(0|false|no|off)$/i.test(text)) return false;
+  return defaultValue;
+};


### PR DESCRIPTION
## Summary
- Modularize skins API module with dedicated types, validators, and helpers
- Clean up router to use new services and clearer variable names
- Export skins router via module index and adjust server entry

## Testing
- ❌ `ESLINT_USE_FLAT_CONFIG=false npm run lint` (112 errors, 95 warnings)
- ⚠️ `ESLINT_USE_FLAT_CONFIG=false npm run check` (script fails: Unknown command "lint")

------
https://chatgpt.com/codex/tasks/task_e_68c57cf5081083328392eafb96cf3cfe