### PR TITLE
Add caching and backoff to reduce Steam rate limits

### DIFF
--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -4,6 +4,6 @@
  */
 export const STEAM_PAGE_SIZE = Math.max(20, Math.min(80, Number(process.env.STEAM_PAGE_SIZE || 30)));
 export const STEAM_MAX_AUTO_LIMIT = Math.max(500, Math.min(5000, Number(process.env.STEAM_MAX_AUTO_LIMIT || 1200))); // «мягкий» cap
-export const START_RATE_MS = Math.max(800, Number(process.env.STEAM_RATE_MS || 2500));
-export const RATE_MIN_MS = 1200;
+export const START_RATE_MS = Math.max(800, Number(process.env.STEAM_RATE_MS || 4000));
+export const RATE_MIN_MS = 2000;
 export const RATE_MAX_MS = 6000;


### PR DESCRIPTION
## Summary
- Throttle Steam request queue harder
- Cache and reuse Steam totals; send friendly 503 on 429
- Retry totals fetch on the client with exponential backoff

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: ESLint couldn't find config)*
- `npx tsc -p server/tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68c582a961f483329b88a9a9249051c1