### PR TITLE
Render progressive loader results

### DIFF
--- a/client/src/modules/skins/SkinsBrowser.tsx
+++ b/client/src/modules/skins/SkinsBrowser.tsx
@@ -29,6 +29,8 @@ export default function SkinsBrowser() {
     loader,
   } = useSkinsBrowser();
 
+  const viewData = data || loader.data;
+
   return (
     <div className="card sbc">
       <div className="h1">Skins Browser</div>
@@ -78,24 +80,24 @@ export default function SkinsBrowser() {
         </div>
       )}
 
-      {!loader.loading && !loading && data && "skins" in data && (
+      {!loader.loading && !loading && viewData && "skins" in viewData && (
         <>
-          <AggTable skins={data.skins} />
+          <AggTable skins={viewData.skins} />
           <div className="small" style={{ marginTop: 8 }}>
-            Items: {data.total}
+            Items: {viewData.total}
           </div>
         </>
       )}
-      {!loader.loading && !loading && data && "items" in data && (
+      {!loader.loading && !loading && viewData && "items" in viewData && (
         <>
-          <FlatTable items={data.items} />
+          <FlatTable items={viewData.items} />
           <div className="small" style={{ marginTop: 8 }}>
-            Items: {data.total}
+            Items: {viewData.total}
           </div>
         </>
       )}
 
-      {!loader.loading && !loading && !data && !error && !loader.error && (
+      {!loader.loading && !loading && !viewData && !error && !loader.error && (
         <div className="small" style={{ marginTop: 8 }}>
           Pick params and compute. EXTERIORS: {EXTERIORS.join(" / ")}.
         </div>


### PR DESCRIPTION
## Summary
- Display progressive loader data in `SkinsBrowser`
- Show default hint when no loader data is available

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: ESLint couldn't find config)*
- `npx eslint -c .eslintrc.cjs "client/**/*.{ts,tsx}" "server/**/*.{ts,tsx}"` *(fails: all files ignored)*
- `npx tsc -b`


------
https://chatgpt.com/codex/tasks/task_e_68c587f023b4833289b97cb0636bb7eb