### PR TITLE
feat: parallelize listing totals

### DIFF
--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -4,6 +4,6 @@
  */
 export const STEAM_PAGE_SIZE = Math.max(20, Math.min(80, Number(process.env.STEAM_PAGE_SIZE || 30)));
 export const STEAM_MAX_AUTO_LIMIT = Math.max(500, Math.min(5000, Number(process.env.STEAM_MAX_AUTO_LIMIT || 1200))); // «мягкий» cap
-export const START_RATE_MS = Math.max(800, Number(process.env.STEAM_RATE_MS || 4000));
-export const RATE_MIN_MS = 2000;
-export const RATE_MAX_MS = 6000;
+export const START_RATE_MS = Math.max(800, Number(process.env.STEAM_RATE_MS || 3000));
+export const RATE_MIN_MS = 1000;
+export const RATE_MAX_MS = 4000;


### PR DESCRIPTION
## Summary
- limit listing totals endpoint to run up to five Steam requests in parallel
- allow Steam repo queue to process requests in batches and reduce request delays
- tweak Steam request rate configuration

## Testing
- `npm test` *(fails: Missing script: "test")*
- `ESLINT_USE_FLAT_CONFIG=false npm run lint` *(fails: 219 problems (116 errors, 103 warnings))*
- `npx tsc -b`


------
https://chatgpt.com/codex/tasks/task_e_68c589de29ac833299c115b69108b328