### PR TITLE
Parallelize remaining Steam API calls

### DIFF
--- a/server/src/modules/skins/service.ts
+++ b/server/src/modules/skins/service.ts
@@ -2,17 +2,24 @@ import { RARITY_TO_TAG, searchByRarity } from "../steam/repo";
 import { type Exterior } from "./types";
 
 /** Supported rarities extracted from Steam mapping. */
-export const ALL_RARITIES = Object.keys(RARITY_TO_TAG) as (keyof typeof RARITY_TO_TAG)[];
+export const ALL_RARITIES = Object.keys(
+  RARITY_TO_TAG,
+) as (keyof typeof RARITY_TO_TAG)[];
 
 /** Extracts exterior from a market_hash_name, defaults to Field-Tested. */
 export const parseMarketHashExterior = (marketHashName: string): Exterior => {
-  const match = marketHashName.match(/\((Factory New|Minimal Wear|Field-Tested|Well-Worn|Battle-Scarred)\)$/i);
+  const match = marketHashName.match(
+    /\((Factory New|Minimal Wear|Field-Tested|Well-Worn|Battle-Scarred)\)$/i,
+  );
   return (match?.[1] as Exterior) ?? "Field-Tested";
 };
 
 /** Removes exterior suffix, returning the base item name. */
 export const baseFromMarketHash = (marketHashName: string): string =>
-  marketHashName.replace(/ \((Factory New|Minimal Wear|Field-Tested|Well-Worn|Battle-Scarred)\)$/i, "");
+  marketHashName.replace(
+    / \((Factory New|Minimal Wear|Field-Tested|Well-Worn|Battle-Scarred)\)$/i,
+    "",
+  );
 
 /**
  * Fetches total_count for each rarity with minimal requests.
@@ -23,10 +30,19 @@ export const getTotals = async (
 ): Promise<{ perRarity: Record<string, number>; sum: number }> => {
   const perRarity: Record<string, number> = {};
   let sum = 0;
-  for (const rarity of rarities) {
-    const { total } = await searchByRarity({ rarity, start: 0, count: 1, normalOnly });
-    perRarity[rarity] = total;
-    sum += total;
+  const concurrency = 5;
+  for (let i = 0; i < rarities.length; i += concurrency) {
+    const slice = rarities.slice(i, i + concurrency);
+    const totals = await Promise.all(
+      slice.map((rarity) =>
+        searchByRarity({ rarity, start: 0, count: 1, normalOnly }),
+      ),
+    );
+    slice.forEach((rarity, idx) => {
+      const total = totals[idx].total;
+      perRarity[rarity] = total;
+      sum += total;
+    });
   }
   return { perRarity, sum };
 };


### PR DESCRIPTION
## Summary
- parallelize priceoverview batch request processing
- batch rarity total lookups with limited concurrency
- run price check and listing total fetches in parallel to ease rate limits

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npx tsc -b`


------
https://chatgpt.com/codex/tasks/task_e_68c58c6324188332be37e80b8610958b