### PR TITLE
feat: add rarity names fetch and save

### DIFF
--- a/client/src/modules/skins/SkinsBrowser.tsx
+++ b/client/src/modules/skins/SkinsBrowser.tsx
@@ -4,7 +4,7 @@ import ControlsBar from "./components/ControlsBar";
 import ProgressBar from "./components/ProgressBar";
 import FlatTable from "./components/FlatTable";
 import AggTable from "./components/AggTable";
-import { EXTERIORS, RARITIES } from "./services";
+import { EXTERIORS, RARITIES, fetchAllNames } from "./services";
 import useSkinsBrowser from "./hooks/useSkinsBrowser";
 
 export default function SkinsBrowser() {
@@ -28,6 +28,24 @@ export default function SkinsBrowser() {
     load,
     loader,
   } = useSkinsBrowser();
+
+  const [savingNames, setSavingNames] = React.useState(false);
+  const [namesMessage, setNamesMessage] = React.useState<string | null>(null);
+  const [namesError, setNamesError] = React.useState<string | null>(null);
+
+  async function handleFetchNames() {
+    setSavingNames(true);
+    setNamesMessage(null);
+    setNamesError(null);
+    try {
+      const result = await fetchAllNames(rarity, normalOnly);
+      setNamesMessage(`Saved ${result.total} names for ${result.rarity}`);
+    } catch (e: any) {
+      setNamesError(String(e?.message || e));
+    } finally {
+      setSavingNames(false);
+    }
+  }
 
   const viewData = data || loader.data;
 
@@ -57,7 +75,8 @@ export default function SkinsBrowser() {
         onLoad={load}
         onLoadProgressive={loader.loadProgressive}
         onResume={loader.resume}
-        loading={loading || loader.loading}
+        onFetchNames={handleFetchNames}
+        loading={loading || loader.loading || savingNames}
         canResume={loader.canResume}
       />
 
@@ -72,6 +91,16 @@ export default function SkinsBrowser() {
       {loader.error && (
         <div className="red" style={{ marginTop: 8 }}>
           {loader.error}
+        </div>
+      )}
+      {namesError && (
+        <div className="red" style={{ marginTop: 8 }}>
+          {namesError}
+        </div>
+      )}
+      {namesMessage && (
+        <div className="small" style={{ marginTop: 8 }}>
+          {namesMessage}
         </div>
       )}
       {hint && (

--- a/client/src/modules/skins/components/ControlsBar.tsx
+++ b/client/src/modules/skins/components/ControlsBar.tsx
@@ -29,6 +29,7 @@ type ControlsBarProps = {
   onLoad: () => void;
   onLoadProgressive: () => void;
   onResume: () => void;
+  onFetchNames: () => void;
 
   loading: boolean;
   canResume: boolean;
@@ -116,6 +117,7 @@ const ControlsBar: React.FC<ControlsBarProps> = (props) => {
         <button className="btn" onClick={props.onLoad} disabled={props.loading}>Load</button>
         <button className="btn" style={{ marginLeft: 8 }} onClick={props.onLoadProgressive} disabled={props.loading}>Load progressively</button>
         <button className="btn" style={{ marginLeft: 8 }} onClick={props.onResume} disabled={props.loading || !props.canResume}>Resume</button>
+        <button className="btn" style={{ marginLeft: 8 }} onClick={props.onFetchNames} disabled={props.loading}>Get names</button>
       </div>
     </div>
   );

--- a/server/src/modules/skins/router.ts
+++ b/server/src/modules/skins/router.ts
@@ -1,6 +1,8 @@
 import { Router } from "express";
 import type { AxiosError } from "axios";
 import { LRUCache } from "lru-cache";
+import fs from "node:fs/promises";
+import path from "node:path";
 import { getPriceUSD, searchByRarity, fetchListingTotalCount } from "../steam/repo";
 import { STEAM_MAX_AUTO_LIMIT, STEAM_PAGE_SIZE } from "../../config";
 import { parseBoolean } from "./validators";
@@ -16,6 +18,8 @@ import {
   type ExpandMode,
   type SkinsGroup,
 } from "./types";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 const totalsCache = new LRUCache<string, { perRarity: Record<string, number>; sum: number }>({
   max: 100,
@@ -140,6 +144,21 @@ export const createSkinsRouter = (): Router => {
             })
           );
         }
+
+        const namesNeedingTotals = flatItems
+          .filter((e) => e.sell_listings === 0)
+          .map((e) => e.market_hash_name);
+        for (const name of Array.from(new Set(namesNeedingTotals))) {
+          const n = await fetchListingTotalCount(name);
+          if (typeof n === "number") {
+            for (const item of flatItems) {
+              if (item.market_hash_name === name && item.sell_listings === 0) {
+                item.sell_listings = n;
+              }
+            }
+          }
+        }
+
         return response.json({ rarities: rarityList, total: flatItems.length, items: flatItems, meta });
       }
 
@@ -262,6 +281,52 @@ export const createSkinsRouter = (): Router => {
 
       const { items, total } = await searchByRarity({ rarity: rarity as any, start, count, normalOnly });
       return response.json({ rarity, start, count: items.length, total, items });
+    } catch (error) {
+      return handleError(response, error);
+    }
+  });
+
+  /**
+   * GET /api/skins/names?rarity=Classified&normalOnly=1
+   * Выгружает все market_hash_name указанной редкости и сохраняет в JSON.
+   */
+  router.get("/names", async (request, response) => {
+    try {
+      const rarity = String(request.query.rarity ?? "");
+      if (!ALL_RARITIES.includes(rarity as any)) {
+        return response.status(400).json({ error: "Invalid rarity" });
+      }
+      const normalOnly = parseBoolean(request.query.normalOnly, true);
+
+      const names: string[] = [];
+      let start = 0;
+      while (true) {
+        try {
+          const { items, total } = await searchByRarity({
+            rarity: rarity as any,
+            start,
+            count: STEAM_PAGE_SIZE,
+            normalOnly,
+          });
+          if (!items.length) break;
+          names.push(...items.map((i) => i.market_hash_name));
+          start += items.length;
+          if (start >= total) break;
+        } catch (err) {
+          const status = (err as AxiosError)?.response?.status;
+          if (status === 429) {
+            await sleep(16_000);
+            continue;
+          }
+          throw err;
+        }
+      }
+
+      const filePath = path.join(process.cwd(), "server", "data", `${rarity}.json`);
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(filePath, JSON.stringify({ rarity, names }, null, 2), "utf8");
+
+      return response.json({ rarity, total: names.length, file: filePath, names });
     } catch (error) {
       return handleError(response, error);
     }

--- a/server/src/modules/steam/repo.ts
+++ b/server/src/modules/steam/repo.ts
@@ -247,7 +247,8 @@ export const searchByRarity = async ({
   const total = payload?.total_count ?? 0;
   const items: SearchItem[] = (payload?.results ?? []).map((result) => ({
     market_hash_name: result.hash_name,
-    sell_listings: result.sell_listings,
+    // Steam иногда возвращает sell_listings строкой, нормализуем в число
+    sell_listings: Number.parseInt(String(result.sell_listings ?? 0), 10) || 0,
     sell_price_text: result.sell_price_text,
   }));
 


### PR DESCRIPTION
## Summary
- allow requesting all market hash names for a selected rarity and saving them to JSON
- expose API helper and UI button to trigger name export from client
- retry Steam requests and show export errors inline instead of blocking alerts
- fix missing listing counts by normalizing sell_listings and filling zero counts from listing pages

## Testing
- `npm run check` *(fails: ESLint couldn't find config)*
- `npx tsc -b --pretty false`


------
https://chatgpt.com/codex/tasks/task_e_68c590b560a48332b70cc72e1d946fc3