### PR TITLE
Expand SearchRenderResponse fields

### DIFF
--- a/server/src/modules/steam/repo.ts
+++ b/server/src/modules/steam/repo.ts
@@ -23,13 +23,32 @@ interface PriceOverviewResponse {
   volume?: string; // строка, бывает "1,234"
 }
 
-/** Формат ответа search/render (урезанный до нужного) */
+/** Формат ответа search/render (расширенный до нужного вида) */
 interface SearchRenderResponse {
   total_count: number;
   results: Array<{
+    name: string;
     hash_name: string;
     sell_listings: number;
-    sell_price_text?: string;
+    sell_price: number;
+    sell_price_text: string;
+    app_icon: string;
+    app_name: string;
+    asset_description: {
+      appid: number;
+      classid: string;
+      instanceid: string;
+      background_color: string;
+      icon_url: string;
+      tradable: number;
+      name: string;
+      name_color: string;
+      type: string;
+      market_name: string;
+      market_hash_name: string;
+      commodity: number;
+    };
+    sale_price_text: string;
   }>;
 }
 


### PR DESCRIPTION
## Summary
- extend SearchRenderResponse with name, price, app info and asset details

## Testing
- `npm test` *(fails: Missing script: "test")*
- `ESLINT_USE_FLAT_CONFIG=false npm run lint` *(fails: 236 problems - Missing JSDoc etc.)*
- `npx tsc -b`

------
https://chatgpt.com/codex/tasks/task_e_68c5f2cf97e483329ee92d17cf17317f