### PR TITLE
feat: add list caching and zero check with spinner

### DIFF
--- a/client/src/modules/skins/SkinsBrowser.css
+++ b/client/src/modules/skins/SkinsBrowser.css
@@ -8,3 +8,22 @@
 .sbc .input, .sbc select { width: 100%; padding: 10px 12px; border-radius: 10px; border: 1px solid #283347; background: #0f1523; color: white; }
 .sbc .btn { padding: 10px 14px; border-radius: 10px; border: 1px solid #2b3b58; background: #162033; color: white; cursor: pointer; }
 .sbc .btn:hover { background: #1d2a44; }
+.sbc .buttons { display: flex; flex-wrap: wrap; gap: 8px; }
+
+.sbc .spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid #2b3b58;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: sbc-spin 1s linear infinite;
+  margin-right: 8px;
+}
+
+@keyframes sbc-spin {
+  to { transform: rotate(360deg); }
+}
+
+.sbc .toast { padding: 8px 12px; border-radius: 6px; }
+.sbc .toast.success { background: #1d2a44; color: #aaffaa; }
+.sbc .toast.error { background: #401020; color: #ffaaaa; }

--- a/client/src/modules/skins/SkinsBrowser.tsx
+++ b/client/src/modules/skins/SkinsBrowser.tsx
@@ -4,7 +4,13 @@ import ControlsBar from "./components/ControlsBar";
 import ProgressBar from "./components/ProgressBar";
 import FlatTable from "./components/FlatTable";
 import AggTable from "./components/AggTable";
-import { EXTERIORS, RARITIES, fetchAllNames } from "./services";
+import {
+  EXTERIORS,
+  RARITIES,
+  fetchAllNames,
+  batchListingTotals,
+  batchPriceOverview,
+} from "./services";
 import useSkinsBrowser from "./hooks/useSkinsBrowser";
 
 export default function SkinsBrowser() {
@@ -23,6 +29,36 @@ export default function SkinsBrowser() {
   const [savingNames, setSavingNames] = React.useState(false);
   const [namesMessage, setNamesMessage] = React.useState<string | null>(null);
   const [namesError, setNamesError] = React.useState<string | null>(null);
+  const [hasOld, setHasOld] = React.useState(false);
+  const [extraProgress, setExtraProgress] = React.useState<string | null>(null);
+  const [toast, setToast] = React.useState<
+    { type: "success" | "error"; text: string } | null
+  >(null);
+
+  React.useEffect(() => {
+    if (loader.data) {
+      try {
+        localStorage.setItem("skins_browser_list", JSON.stringify(loader.data));
+        setHasOld(true);
+      } catch {
+        /* ignore */
+      }
+    }
+  }, [loader.data]);
+
+  React.useEffect(() => {
+    try {
+      const s = localStorage.getItem("skins_browser_list");
+      setHasOld(Boolean(s));
+    } catch {
+      setHasOld(false);
+    }
+  }, []);
+
+  function showToast(type: "success" | "error", text: string) {
+    setToast({ type, text });
+    setTimeout(() => setToast(null), 3000);
+  }
 
   async function handleFetchNames() {
     setSavingNames(true);
@@ -35,6 +71,74 @@ export default function SkinsBrowser() {
       setNamesError(String(e?.message || e));
     } finally {
       setSavingNames(false);
+    }
+  }
+
+  async function handleShowOldList() {
+    setExtraProgress("Loading saved list…");
+    try {
+      const s = localStorage.getItem("skins_browser_list");
+      if (!s) throw new Error("No saved list");
+      const parsed = JSON.parse(s);
+      loader.setData(parsed);
+      showToast("success", "Loaded saved list");
+    } catch (e: any) {
+      showToast("error", String(e?.message || e));
+    } finally {
+      setExtraProgress(null);
+    }
+  }
+
+  async function handleCheckZero() {
+    if (!loader.data) {
+      showToast("error", "Nothing to check");
+      return;
+    }
+    setExtraProgress("Checking listings…");
+    try {
+      const zeroNames = new Set<string>();
+      const priceNames = new Set<string>();
+      const d: any = loader.data;
+      if ("skins" in d) {
+        d.skins.forEach((s: any) =>
+          s.exteriors.forEach((e: any) => {
+            if (!e.sell_listings) zeroNames.add(e.marketHashName);
+            if (e.price == null) priceNames.add(e.marketHashName);
+          }),
+        );
+      } else if ("items" in d) {
+        d.items.forEach((i: any) => {
+          if (!i.sell_listings) zeroNames.add(i.market_hash_name);
+          if (i.price == null) priceNames.add(i.market_hash_name);
+        });
+      }
+      const [totals, prices] = await Promise.all([
+        zeroNames.size ? batchListingTotals(Array.from(zeroNames)) : ({} as any),
+        priceNames.size ? batchPriceOverview(Array.from(priceNames)) : ({} as any),
+      ]);
+      if ("skins" in d) {
+        d.skins.forEach((s: any) =>
+          s.exteriors.forEach((e: any) => {
+            const n = (totals as any)[e.marketHashName];
+            if (typeof n === "number") e.sell_listings = n;
+            const p = (prices as any)[e.marketHashName];
+            if (typeof p === "number") e.price = p;
+          }),
+        );
+      } else if ("items" in d) {
+        d.items.forEach((i: any) => {
+          const n = (totals as any)[i.market_hash_name];
+          if (typeof n === "number") i.sell_listings = n;
+          const p = (prices as any)[i.market_hash_name];
+          if (typeof p === "number") i.price = p;
+        });
+      }
+      loader.setData({ ...d });
+      showToast("success", "Check complete");
+    } catch (e: any) {
+      showToast("error", String(e?.message || e));
+    } finally {
+      setExtraProgress(null);
     }
   }
 
@@ -61,11 +165,14 @@ export default function SkinsBrowser() {
         expandOptions={["none", "price", "all"]}
         onLoadProgressive={loader.loadProgressive}
         onFetchNames={handleFetchNames}
-        loading={loader.loading || savingNames}
+        onShowOldList={handleShowOldList}
+        onCheckZero={handleCheckZero}
+        hasOldList={hasOld}
+        loading={loader.loading || savingNames || Boolean(extraProgress)}
       />
 
-      {(loader.progress || loader.loading) && (
-        <ProgressBar text={loader.progress || "Loading…"} />
+      {(loader.progress || extraProgress || loader.loading) && (
+        <ProgressBar text={loader.progress || extraProgress || "Loading…"} />
       )}
       {loader.error && (
         <div className="red" style={{ marginTop: 8 }}>
@@ -100,7 +207,12 @@ export default function SkinsBrowser() {
       )}
       {!loader.loading && !viewData && !loader.error && (
         <div className="small" style={{ marginTop: 8 }}>
-          Pick params and compute. EXTERIORS: {EXTERIORS.join(" / ")}.
+          Pick params and compute. EXTERIORS: {EXTERIORS.join(" / ")}. 
+        </div>
+      )}
+      {toast && (
+        <div className={`toast ${toast.type}`} style={{ marginTop: 8 }}>
+          {toast.text}
         </div>
       )}
     </div>

--- a/client/src/modules/skins/components/ControlsBar.tsx
+++ b/client/src/modules/skins/components/ControlsBar.tsx
@@ -20,6 +20,9 @@ type ControlsBarProps = {
   expandOptions: ReadonlyArray<ExpandMode>;           // ← было: ExpandMode[]
   onLoadProgressive: () => void;
   onFetchNames: () => void;
+  onShowOldList: () => void;
+  onCheckZero: () => void;
+  hasOldList: boolean;
   loading: boolean;
 };
 
@@ -76,9 +79,11 @@ const ControlsBar: React.FC<ControlsBarProps> = (props) => {
         </select>
       </div>
 
-      <div style={{ alignSelf: "end" }}>
+      <div className="buttons" style={{ alignSelf: "end" }}>
         <button className="btn" onClick={props.onLoadProgressive} disabled={props.loading}>Load progressively</button>
-        <button className="btn" style={{ marginLeft: 8 }} onClick={props.onFetchNames} disabled={props.loading}>Get names</button>
+        <button className="btn" onClick={props.onFetchNames} disabled={props.loading}>Get names</button>
+        <button className="btn" onClick={props.onShowOldList} disabled={!props.hasOldList || props.loading}>Show old list</button>
+        <button className="btn" onClick={props.onCheckZero} disabled={props.loading}>Check Zero</button>
       </div>
     </div>
   );

--- a/client/src/modules/skins/components/ProgressBar.tsx
+++ b/client/src/modules/skins/components/ProgressBar.tsx
@@ -2,8 +2,12 @@ import React from "react";
 
 export default function ProgressBar({ text }: { text: string }) {
   return (
-    <div className="small" style={{ marginTop: 8 }}>
-      {text}
+    <div
+      className="small"
+      style={{ marginTop: 8, display: "flex", alignItems: "center" }}
+    >
+      <div className="spinner" />
+      <span>{text}</span>
     </div>
   );
 }

--- a/client/src/modules/skins/hooks/useProgressiveLoader.ts
+++ b/client/src/modules/skins/hooks/useProgressiveLoader.ts
@@ -131,7 +131,11 @@ export default function useProgressiveLoader(params: Params) {
   }
 
   return {
-    data, loading, progress, error,
+    data,
+    loading,
+    progress,
+    error,
     loadProgressive,
+    setData,
   };
 }


### PR DESCRIPTION
## Summary
- cache loaded lists in localStorage and allow reloading via **Show old list**
- add **Check Zero** to refresh empty listings
- show spinner progress and toast notifications; align control buttons

## Testing
- `npm test` (fails: Missing script)
- `npm run check` (fails: ESLint couldn't find config)
- `npx tsc -b`


------
https://chatgpt.com/codex/tasks/task_e_68c5f8fe4b5083329cda40d0ffe5d0fc