### PR TITLE
Add price and listing management controls

### DIFF
--- a/client/src/modules/skins/components/ControlsBar.tsx
+++ b/client/src/modules/skins/components/ControlsBar.tsx
@@ -18,10 +18,17 @@ type ControlsBarProps = {
   expandExteriors: ExpandMode;
   setExpandExteriors: (next: ExpandMode) => void;
   expandOptions: ReadonlyArray<ExpandMode>;           // ← было: ExpandMode[]
+  actualPrices: boolean;
+  setActualPrices: (next: boolean) => void;
+  actualListings: boolean;
+  setActualListings: (next: boolean) => void;
   onLoadProgressive: () => void;
   onFetchNames: () => void;
   onShowOldList: () => void;
-  onCheckZero: () => void;
+  onAddCorrectPrice: () => void;
+  onFixZeroPrice: () => void;
+  onAddCorrectListings: () => void;
+  onFixZeroListings: () => void;
   hasOldList: boolean;
   loading: boolean;
 };
@@ -79,11 +86,32 @@ const ControlsBar: React.FC<ControlsBarProps> = (props) => {
         </select>
       </div>
 
+      <div>
+        <div className="label">Actual prices</div>
+        <input
+          type="checkbox"
+          checked={props.actualPrices}
+          onChange={(e) => props.setActualPrices(e.target.checked)}
+        />
+      </div>
+
+      <div>
+        <div className="label">Actual listings</div>
+        <input
+          type="checkbox"
+          checked={props.actualListings}
+          onChange={(e) => props.setActualListings(e.target.checked)}
+        />
+      </div>
+
       <div className="buttons" style={{ alignSelf: "end" }}>
         <button className="btn" onClick={props.onLoadProgressive} disabled={props.loading}>Load progressively</button>
         <button className="btn" onClick={props.onFetchNames} disabled={props.loading}>Get names</button>
         <button className="btn" onClick={props.onShowOldList} disabled={!props.hasOldList || props.loading}>Show old list</button>
-        <button className="btn" onClick={props.onCheckZero} disabled={props.loading}>Check Zero</button>
+        <button className="btn" onClick={props.onAddCorrectPrice} disabled={props.loading}>Add correct price</button>
+        <button className="btn" onClick={props.onFixZeroPrice} disabled={props.loading}>Fix zero price</button>
+        <button className="btn" onClick={props.onAddCorrectListings} disabled={props.loading}>Add correct listings</button>
+        <button className="btn" onClick={props.onFixZeroListings} disabled={props.loading}>Fix zero listings</button>
       </div>
     </div>
   );

--- a/client/src/modules/skins/hooks/useProgressiveLoader.ts
+++ b/client/src/modules/skins/hooks/useProgressiveLoader.ts
@@ -16,10 +16,12 @@ type Params = {
   aggregate: boolean;
   normalOnly: boolean;
   expandExteriors: ExpandMode;
+  actualPrices: boolean;
+  actualListings: boolean;
 };
 
 export default function useProgressiveLoader(params: Params) {
-  const { rarity, aggregate, normalOnly, expandExteriors } = params;
+  const { rarity, aggregate, normalOnly, expandExteriors, actualPrices, actualListings } = params;
   const [data, setData] = useState<ApiAggResp | ApiFlatResp | null>(null);
   const [loading, setLoading] = useState(false);
   const [progress, setProgress] = useState<string | null>(null);
@@ -64,10 +66,13 @@ export default function useProgressiveLoader(params: Params) {
 
       if (!aggregate) {
         const out: ApiFlatResp = { rarities: [rarity], total: flat.length, items: flat };
-        const missing = flat.filter(x => x.price == null).map(x => x.market_hash_name);
-        if (missing.length) {
-          const pmap = await batchPriceOverview(Array.from(new Set(missing)));
-          out.items.forEach(x => { if (x.price == null) (x as any).price = pmap[x.market_hash_name] ?? null; });
+        if (actualListings) {
+          const tmap = await batchListingTotals(Array.from(new Set(flat.map(x => x.market_hash_name))));
+          out.items.forEach(x => { const n = tmap[x.market_hash_name]; if (typeof n === "number") (x as any).sell_listings = n; });
+        }
+        if (actualPrices) {
+          const pmap = await batchPriceOverview(Array.from(new Set(flat.map(x => x.market_hash_name))));
+          out.items.forEach(x => { const p = pmap[x.market_hash_name]; if (typeof p === "number") (x as any).price = p; });
         }
         setData(out); setProgress(null);
         return;
@@ -79,7 +84,7 @@ export default function useProgressiveLoader(params: Params) {
       const needPriceCheck: string[] = [];
       Object.values(groups).forEach(g => {
         const present = new Set(g.exteriors.map(e => e.exterior));
-        if (expandExteriors === "all" || expandExteriors === "price") {
+        if (expandExteriors === "all" || (expandExteriors === "price" && actualPrices)) {
           for (const ext of EXTERIORS) {
             if (present.has(ext)) continue;
             const mhn = `${g.baseName} (${ext})`;
@@ -91,7 +96,7 @@ export default function useProgressiveLoader(params: Params) {
           }
         }
       });
-      if (expandExteriors === "price" && needPriceCheck.length) {
+      if (expandExteriors === "price" && actualPrices && needPriceCheck.length) {
         const pmap = await batchPriceOverview(needPriceCheck);
         Object.values(groups).forEach(g => {
           for (const ext of EXTERIORS) {
@@ -103,21 +108,26 @@ export default function useProgressiveLoader(params: Params) {
         });
       }
 
-      // prices for all
-      const toPrice = Object.values(groups).flatMap(g => g.exteriors.filter(e => e.price == null).map(e => e.marketHashName));
-      if (toPrice.length) {
-        const pmap = await batchPriceOverview(Array.from(new Set(toPrice)));
-        Object.values(groups).forEach(g => g.exteriors.forEach(e => { if (e.price == null) e.price = pmap[e.marketHashName] ?? null; }));
+      if (actualPrices) {
+        const toPrice = Object.values(groups).flatMap(g => g.exteriors.map(e => e.marketHashName));
+        if (toPrice.length) {
+          const pmap = await batchPriceOverview(Array.from(new Set(toPrice)));
+          Object.values(groups).forEach(g => g.exteriors.forEach(e => {
+            const p = pmap[e.marketHashName];
+            if (p != null) e.price = p;
+          }));
+        }
       }
 
-      // fix zero listings with listing totals
-      const needTotals = Object.values(groups).flatMap(g => g.exteriors.filter(e => e.sell_listings === 0).map(e => e.marketHashName));
-      if (needTotals.length) {
-        const tmap = await batchListingTotals(Array.from(new Set(needTotals)));
-        Object.values(groups).forEach(g => g.exteriors.forEach(e => {
-          const n = tmap[e.marketHashName];
-          if (typeof n === "number" && n > e.sell_listings) e.sell_listings = n;
-        }));
+      if (actualListings) {
+        const needTotals = Object.values(groups).flatMap(g => g.exteriors.map(e => e.marketHashName));
+        if (needTotals.length) {
+          const tmap = await batchListingTotals(Array.from(new Set(needTotals)));
+          Object.values(groups).forEach(g => g.exteriors.forEach(e => {
+            const n = tmap[e.marketHashName];
+            if (typeof n === "number") e.sell_listings = n;
+          }));
+        }
       }
 
       const skins = Object.values(groups).sort((a, b) => a.baseName.localeCompare(b.baseName));

--- a/client/src/modules/skins/hooks/useSkinsBrowser.ts
+++ b/client/src/modules/skins/hooks/useSkinsBrowser.ts
@@ -7,12 +7,16 @@ export default function useSkinsBrowser() {
   const [aggregate, setAggregate] = useState(true);
   const [normalOnly, setNormalOnly] = useState(true);
   const [expandExteriors, setExpandExteriors] = useState<ExpandMode>("all");
+  const [actualPrices, setActualPrices] = useState(true);
+  const [actualListings, setActualListings] = useState(true);
 
   const loader = useProgressiveLoader({
     rarity,
     aggregate,
     normalOnly,
     expandExteriors,
+    actualPrices,
+    actualListings,
   });
 
   return {
@@ -24,6 +28,10 @@ export default function useSkinsBrowser() {
     setNormalOnly,
     expandExteriors,
     setExpandExteriors,
+    actualPrices,
+    setActualPrices,
+    actualListings,
+    setActualListings,
     loader,
   } as const;
 }


### PR DESCRIPTION
## Summary
- allow toggling actual price and listing fetching on load
- add buttons to refresh or fix missing prices and listings

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ffdd0cb48332a26fa059e2e696d8