### PR TITLE
feat: add sorting and bootstrap styling

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,20 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CS2 Trade‑Up EV</title>
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT1w0nPc+1MTF0i2Q7WlX04"
-      crossOrigin="anonymous"
-    />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
 </head>
 <body>
 <div id="root"></div>
-<script
-  src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
-  integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9b40+TULyZq49srN1qE8B602p3Dd1KGj7Sk" 
-  crossOrigin="anonymous"
-></script>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+</body>
 <script type="module" src="/src/main.tsx"></script>
 </body>
 </html>

--- a/client/index.html
+++ b/client/index.html
@@ -4,9 +4,20 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>CS2 Trade‑Up EV</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT1w0nPc+1MTF0i2Q7WlX04"
+      crossOrigin="anonymous"
+    />
 </head>
 <body>
 <div id="root"></div>
+<script
+  src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9b40+TULyZq49srN1qE8B602p3Dd1KGj7Sk" 
+  crossOrigin="anonymous"
+></script>
 <script type="module" src="/src/main.tsx"></script>
 </body>
 </html>

--- a/client/node_modules/.vite/deps/_metadata.json
+++ b/client/node_modules/.vite/deps/_metadata.json
@@ -1,25 +1,25 @@
 {
-  "hash": "8187992a",
+  "hash": "2aab46fc",
   "configHash": "577e069c",
-  "lockfileHash": "fcd484f9",
-  "browserHash": "e691b694",
+  "lockfileHash": "41bfd0f8",
+  "browserHash": "7c300c52",
   "optimized": {
     "react": {
       "src": "../../../../node_modules/react/index.js",
       "file": "react.js",
-      "fileHash": "74263b2c",
+      "fileHash": "07e7b622",
       "needsInterop": true
     },
     "react-dom/client": {
       "src": "../../../../node_modules/react-dom/client.js",
       "file": "react-dom_client.js",
-      "fileHash": "b5d46ac6",
+      "fileHash": "6e46bba7",
       "needsInterop": true
     },
     "react/jsx-dev-runtime": {
       "src": "../../../../node_modules/react/jsx-dev-runtime.js",
       "file": "react_jsx-dev-runtime.js",
-      "fileHash": "ae16458e",
+      "fileHash": "9c235321",
       "needsInterop": true
     }
   },

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -5,8 +5,8 @@ import SkinsBrowser from "./modules/skins";
  * Главная страница приложения — содержит только компонент SkinsBrowser.
  */
 const App: React.FC = () => (
-    <div className="container">
-        <div className="card" style={{ marginBottom: 12 }}>
+    <div className="container mt-4">
+        <div className="card bg-dark text-white mb-3 p-3">
             <div className="h1">CS2 Skins — Market Browser</div>
             <div className="small">Live Steam prices • Stable pagination • Progressive loading</div>
         </div>

--- a/client/src/modules/skins/SkinsBrowser.css
+++ b/client/src/modules/skins/SkinsBrowser.css
@@ -1,16 +1,3 @@
-.sbc .controls-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 12px;
-    margin-top: 8px;
-}
-.sbc .label { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .08em; }
-.sbc .input, .sbc select { width: 100%; padding: 10px 12px; border-radius: 10px; border: 1px solid #283347; background: #0f1523; color: white; }
-.sbc .btn { padding: 10px 14px; border-radius: 10px; border: 1px solid #2b3b58; background: #162033; color: white; cursor: pointer; }
-.sbc .btn:hover { background: #1d2a44; }
-.sbc .buttons { display: flex; flex-wrap: wrap; gap: 8px; }
-
-.sbc .btn-wrap { display: flex; align-items: center; gap: 4px; }
 .sbc .help { width: 16px; height: 16px; border-radius: 50%; border: 1px solid #2b3b58; display: inline-flex; align-items: center; justify-content: center; font-size: 12px; cursor: help; color: var(--muted); }
 
 .sbc .spinner {

--- a/client/src/modules/skins/SkinsBrowser.tsx
+++ b/client/src/modules/skins/SkinsBrowser.tsx
@@ -260,7 +260,7 @@ export default function SkinsBrowser() {
   const viewData = loader.data;
 
   return (
-    <div className="card sbc">
+    <div className="card sbc p-3">
       <div className="h1">Skins Browser</div>
       <div className="small">
         Fetch skins by rarity from Steam Market. Progressive mode avoids rate

--- a/client/src/modules/skins/components/AggTable.tsx
+++ b/client/src/modules/skins/components/AggTable.tsx
@@ -2,31 +2,60 @@ import React from "react";
 import { EXTERIORS, type AggGroup } from "../services";
 
 const fmt = (n: number | null | undefined) => (n == null ? "—" : `$${n.toFixed(2)}`);
+type SortField = "name" | "price" | "listings";
 
 export default function AggTable({ skins }: { skins: AggGroup[] }) {
+  const [field, setField] = React.useState<SortField>("name");
+  const [asc, setAsc] = React.useState(true);
+
+  const rows = React.useMemo(() =>
+    skins.flatMap((g) =>
+      g.exteriors
+        .slice()
+        .sort((a, b) => EXTERIORS.indexOf(a.exterior) - EXTERIORS.indexOf(b.exterior))
+        .map((e) => ({
+          baseName: g.baseName,
+          exterior: e.exterior,
+          sell_listings: e.sell_listings,
+          price: e.price,
+        })),
+    ),
+  [skins]);
+
+  const sorted = React.useMemo(() => {
+    return [...rows].sort((a, b) => {
+      let res = 0;
+      if (field === "name") res = a.baseName.localeCompare(b.baseName);
+      if (field === "price") res = (a.price ?? 0) - (b.price ?? 0);
+      if (field === "listings") res = a.sell_listings - b.sell_listings;
+      return asc ? res : -res;
+    });
+  }, [rows, field, asc]);
+
+  const handle = (f: SortField) => {
+    if (field === f) setAsc(!asc); else { setField(f); setAsc(true); }
+  };
+  const arrow = (f: SortField) => field === f ? (asc ? "▲" : "▼") : "";
+
   return (
-    <table className="table" style={{ marginTop: 8 }}>
+    <table className="table table-striped mt-2">
       <thead>
       <tr>
-        <th style={{textAlign:'left'}}>Skin</th>
-        <th style={{textAlign:'left'}}>Exterior</th>
-        <th>Listings</th>
-        <th>Price</th>
+        <th className="text-start" style={{cursor:"pointer"}} onClick={() => handle("name")}>Skin {arrow("name")}</th>
+        <th className="text-start">Exterior</th>
+        <th style={{cursor:"pointer"}} onClick={() => handle("listings")}>Listings {arrow("listings")}</th>
+        <th style={{cursor:"pointer"}} onClick={() => handle("price")}>Price {arrow("price")}</th>
       </tr>
       </thead>
       <tbody>
-      {skins.map((g) =>
-        g.exteriors
-          .sort((a,b) => EXTERIORS.indexOf(a.exterior) - EXTERIORS.indexOf(b.exterior))
-          .map((e, i) => (
-            <tr key={`${g.baseName}-${e.exterior}-${i}`}>
-              <td>{g.baseName}</td>
-              <td>{e.exterior}</td>
-              <td>{e.sell_listings}</td>
-              <td>{fmt(e.price)}</td>
-            </tr>
-          ))
-      )}
+      {sorted.map((r, i) => (
+        <tr key={`${r.baseName}-${r.exterior}-${i}`}>
+          <td>{r.baseName}</td>
+          <td>{r.exterior}</td>
+          <td>{r.sell_listings}</td>
+          <td>{fmt(r.price)}</td>
+        </tr>
+      ))}
       </tbody>
     </table>
   );

--- a/client/src/modules/skins/components/ControlsBar.tsx
+++ b/client/src/modules/skins/components/ControlsBar.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import type { ExpandMode, Rarity } from "../services";
 
 const Help: React.FC<{ text: string }> = ({ text }) => (
-  <span className="help" title={text}>?</span>
+  <span className="help ms-2" title={text}>?</span>
 );
 
 /**
@@ -39,114 +39,124 @@ type ControlsBarProps = {
 
 const ControlsBar: React.FC<ControlsBarProps> = (props) => {
   return (
-    <div className="controls-grid">
-      <div>
-        <div className="label">
-          Rarity <Help text="Choose rarity to fetch" />
+    <div>
+      <div className="row row-cols-1 row-cols-sm-2 row-cols-md-3 g-3 mt-2">
+        <div className="col">
+          <label className="form-label">
+            Rarity <Help text="Choose rarity to fetch" />
+          </label>
+          <select
+            className="form-select"
+            value={props.rarity}
+            onChange={(e) => props.setRarity(e.target.value as Rarity)}
+          >
+            {props.rarityOptions.map((option) => (
+              <option key={option} value={option}>{option}</option>
+            ))}
+          </select>
         </div>
-        <select
-          className="input"
-          value={props.rarity}
-          onChange={(e) => props.setRarity(e.target.value as Rarity)}
-        >
-          {props.rarityOptions.map((option) => (
-            <option key={option} value={option}>{option}</option>
-          ))}
-        </select>
+
+        <div className="col">
+          <label className="form-label">
+            Aggregate <Help text="Group by base name" />
+          </label>
+          <select
+            className="form-select"
+            value={props.aggregate ? "1" : "0"}
+            onChange={(e) => props.setAggregate(e.target.value === "1")}
+          >
+            <option value="1">Yes</option>
+            <option value="0">No (flat)</option>
+          </select>
+        </div>
+
+        <div className="col">
+          <label className="form-label">
+            Normal only <Help text="Exclude StatTrak and Souvenir" />
+          </label>
+          <select
+            className="form-select"
+            value={props.normalOnly ? "1" : "0"}
+            onChange={(e) => props.setNormalOnly(e.target.value === "1")}
+          >
+            <option value="1">Yes (no ST/Souv)</option>
+            <option value="0">No</option>
+          </select>
+        </div>
+
+        <div className="col">
+          <label className="form-label">
+            Expand exteriors <Help text="Add missing exterior variants" />
+          </label>
+          <select
+            className="form-select"
+            value={props.expandExteriors}
+            onChange={(e) => props.setExpandExteriors(e.target.value as ExpandMode)}
+          >
+            {props.expandOptions.map((mode) => (
+              <option key={mode} value={mode}>{mode}</option>
+            ))}
+          </select>
+        </div>
+
+        <div className="col">
+          <div className="form-check mt-4">
+            <input
+              className="form-check-input"
+              type="checkbox"
+              id="actualPrices"
+              checked={props.actualPrices}
+              onChange={(e) => props.setActualPrices(e.target.checked)}
+            />
+            <label className="form-check-label" htmlFor="actualPrices">
+              Actual prices <Help text="Fetch live prices on load" />
+            </label>
+          </div>
+        </div>
+
+        <div className="col">
+          <div className="form-check mt-4">
+            <input
+              className="form-check-input"
+              type="checkbox"
+              id="actualListings"
+              checked={props.actualListings}
+              onChange={(e) => props.setActualListings(e.target.checked)}
+            />
+            <label className="form-check-label" htmlFor="actualListings">
+              Actual listings <Help text="Fetch live listing counts" />
+            </label>
+          </div>
+        </div>
       </div>
 
-      <div>
-        <div className="label">
-          Aggregate <Help text="Group by base name" />
-        </div>
-        <select
-          className="input"
-          value={props.aggregate ? "1" : "0"}
-          onChange={(e) => props.setAggregate(e.target.value === "1")}
-        >
-          <option value="1">Yes</option>
-          <option value="0">No (flat)</option>
-        </select>
-      </div>
-
-      <div>
-        <div className="label">
-          Normal only <Help text="Exclude StatTrak and Souvenir" />
-        </div>
-        <select
-          className="input"
-          value={props.normalOnly ? "1" : "0"}
-          onChange={(e) => props.setNormalOnly(e.target.value === "1")}
-        >
-          <option value="1">Yes (no ST/Souv)</option>
-          <option value="0">No</option>
-        </select>
-      </div>
-
-      <div>
-        <div className="label">
-          Expand exteriors <Help text="Add missing exterior variants" />
-        </div>
-        <select
-          className="input"
-          value={props.expandExteriors}
-          onChange={(e) => props.setExpandExteriors(e.target.value as ExpandMode)}
-        >
-          {props.expandOptions.map((mode) => (
-            <option key={mode} value={mode}>{mode}</option>
-          ))}
-        </select>
-      </div>
-
-      <div>
-        <div className="label">
-          Actual prices <Help text="Fetch live prices on load" />
-        </div>
-        <input
-          type="checkbox"
-          checked={props.actualPrices}
-          onChange={(e) => props.setActualPrices(e.target.checked)}
-        />
-      </div>
-
-      <div>
-        <div className="label">
-          Actual listings <Help text="Fetch live listing counts" />
-        </div>
-        <input
-          type="checkbox"
-          checked={props.actualListings}
-          onChange={(e) => props.setActualListings(e.target.checked)}
-        />
-      </div>
-
-      <div className="buttons" style={{ alignSelf: "end" }}>
-        <div className="btn-wrap">
-          <button className="btn" onClick={props.onLoadProgressive} disabled={props.loading}>Load progressively</button>
+      <div className="row row-cols-1 row-cols-sm-2 row-cols-md-3 g-2 mt-2">
+        <div className="col d-flex align-items-center gap-2">
+          <button className="btn btn-primary w-100" onClick={props.onLoadProgressive} disabled={props.loading}>Load progressively</button>
           <Help text="Load items page by page" />
         </div>
-        <div className="btn-wrap">
-          <button className="btn" onClick={props.onFetchNames} disabled={props.loading}>Get names</button>
+        <div className="col d-flex align-items-center gap-2">
+          <button className="btn btn-primary w-100" onClick={props.onFetchNames} disabled={props.loading}>Get names</button>
           <Help text="Store market hash names" />
         </div>
-        <div className="btn-wrap">
-          <button className="btn" onClick={props.onShowOldList} disabled={!props.hasOldList || props.loading}>Show old list</button>
+        <div className="col d-flex align-items-center gap-2">
+          <button className="btn btn-primary w-100" onClick={props.onShowOldList} disabled={!props.hasOldList || props.loading}>Show old list</button>
           <Help text="Load list from local storage" />
         </div>
-        <div className="btn-wrap">
-          <button className="btn" onClick={props.onAddCorrectPrice} disabled={props.loading}>Add correct price</button>
+        <div className="col d-flex align-items-center gap-2">
+          <button className="btn btn-primary w-100" onClick={props.onAddCorrectPrice} disabled={props.loading}>Add correct price</button>
           <Help text="Refresh prices for all items" />
         </div>
-        <div className="btn-wrap">
-          <button className="btn" onClick={props.onFixZeroPrice} disabled={props.loading}>Fix zero price</button>
+        <div className="col d-flex align-items-center gap-2">
+          <button className="btn btn-primary w-100" onClick={props.onFixZeroPrice} disabled={props.loading}>Fix zero price</button>
           <Help text="Update items with missing price" />
         </div>
-        <div className="btn-wrap">
-          <button className="btn" onClick={props.onAddCorrectListings} disabled={props.loading}>Add correct listings</button>
+        <div className="col d-flex align-items-center gap-2">
+          <button className="btn btn-primary w-100" onClick={props.onAddCorrectListings} disabled={props.loading}>Add correct listings</button>
           <Help text="Refresh listing totals for all items" />
         </div>
-        <div className="btn-wrap">
-          <button className="btn" onClick={props.onFixZeroListings} disabled={props.loading}>Fix zero listings</button>
+        <div className="col d-flex align-items-center gap-2">
+          <button className="btn btn-primary w-100" onClick={props.onFixZeroListings} disabled={props.loading}>Fix zero listings</button>
           <Help text="Update items with missing listings" />
         </div>
       </div>

--- a/client/src/modules/skins/components/FlatTable.tsx
+++ b/client/src/modules/skins/components/FlatTable.tsx
@@ -2,21 +2,41 @@ import React from "react";
 import { parseExterior } from "../services";
 
 type Item = { market_hash_name: string; sell_listings: number; price?: number | null };
+type SortField = "name" | "price" | "listings";
 
 export default function FlatTable({ items }: { items: Item[] }) {
+  const [field, setField] = React.useState<SortField>("name");
+  const [asc, setAsc] = React.useState(true);
+
   const fmt = (n: number | null | undefined) => (n == null ? "—" : `$${n.toFixed(2)}`);
+
+  const sorted = React.useMemo(() => {
+    return [...items].sort((a, b) => {
+      let res = 0;
+      if (field === "name") res = a.market_hash_name.localeCompare(b.market_hash_name);
+      if (field === "price") res = (a.price ?? 0) - (b.price ?? 0);
+      if (field === "listings") res = a.sell_listings - b.sell_listings;
+      return asc ? res : -res;
+    });
+  }, [items, field, asc]);
+
+  const handle = (f: SortField) => {
+    if (field === f) setAsc(!asc); else { setField(f); setAsc(true); }
+  };
+  const arrow = (f: SortField) => field === f ? (asc ? "▲" : "▼") : "";
+
   return (
-    <table className="table" style={{ marginTop: 8 }}>
+    <table className="table table-striped mt-2">
       <thead>
       <tr>
-        <th style={{textAlign:'left'}}>Market hash name</th>
-        <th>Exterior</th>
-        <th>Listings</th>
-        <th>Price</th>
+        <th className="text-start" style={{cursor:"pointer"}} onClick={() => handle("name")}>Market hash name {arrow("name")}</th>
+        <th className="text-start">Exterior</th>
+        <th style={{cursor:"pointer"}} onClick={() => handle("listings")}>Listings {arrow("listings")}</th>
+        <th style={{cursor:"pointer"}} onClick={() => handle("price")}>Price {arrow("price")}</th>
       </tr>
       </thead>
       <tbody>
-      {items.map((x, i) => (
+      {sorted.map((x, i) => (
         <tr key={i}>
           <td>{x.market_hash_name}</td>
           <td>{parseExterior(x.market_hash_name)}</td>

--- a/client/src/styles.css
+++ b/client/src/styles.css
@@ -1,17 +1,8 @@
 :root { --bg: #0b0f17; --card: #121826; --muted: #a3b1c2; --acc: #4fc3f7; }
 * { box-sizing: border-box; }
 body { margin: 0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Inter, Arial; background: var(--bg); color: white; }
-.container { max-width: 980px; margin: 24px auto; padding: 0 16px; }
-.card { background: var(--card); border-radius: 16px; padding: 16px; box-shadow: 0 4px 24px rgba(0,0,0,0.25); }
-.row { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px,1fr)); gap: 12px; }
-.label { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .08em; }
-.input, select { width: 100%; padding: 10px 12px; border-radius: 10px; border: 1px solid #283347; background: #0f1523; color: white; }
-.btn { padding: 10px 14px; border-radius: 10px; border: 1px solid #2b3b58; background: #162033; color: white; cursor: pointer; }
-.btn:hover { background: #1d2a44; }
 .h1 { font-size: 22px; margin: 0 0 8px; }
 .small { color: var(--muted); font-size: 13px; }
 .badge { display: inline-block; background: #11233a; color: var(--acc); padding: 4px 8px; border-radius: 999px; font-size: 12px; }
-.table { width: 100%; border-collapse: collapse; }
-.table td, .table th { border-top: 1px solid #22314a; padding: 8px; font-size: 14px; }
 .green { color: #8ef08e; }
 .red { color: #ff8e8e; }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "client"
       ],
       "dependencies": {
+        "bootstrap": "^5.3.8",
         "dotenv": "^17.2.2",
         "prettier": "^3.6.2",
         "server": "^1.0.42"
@@ -915,6 +916,17 @@
       },
       "funding": {
         "url": "https://opencollective.com/unts"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1923,6 +1935,25 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bootstrap": {
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
+      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -14,14 +14,15 @@
     "check": "npm run lint && tsc -b"
   },
   "devDependencies": {
-    "concurrently": "^8.2.2",
-    "eslint": "^9.9.0",
     "@typescript-eslint/eslint-plugin": "^8.0.1",
     "@typescript-eslint/parser": "^8.0.1",
+    "concurrently": "^8.2.2",
+    "eslint": "^9.9.0",
     "eslint-plugin-jsdoc": "^48.2.7",
     "prettier": "^3.3.3"
   },
   "dependencies": {
+    "bootstrap": "^5.3.8",
     "dotenv": "^17.2.2",
     "prettier": "^3.6.2",
     "server": "^1.0.42"

--- a/server/src/modules/steam/repo.ts
+++ b/server/src/modules/steam/repo.ts
@@ -178,9 +178,27 @@ const steamGetData = async <T = unknown>(
  * Возвращает число в USD (если currency=1) либо null, если распарсить нельзя.
  */
 const parseSteamPriceText = (text: string): number | null => {
-  const normalized = String(text)
-    .replace(/[^0-9.,]/g, "")
-    .replace(",", ".");
+  const cleaned = String(text).replace(/[^0-9.,]/g, "");
+  if (!cleaned) return null;
+  const hasDot = cleaned.includes(".");
+  const hasComma = cleaned.includes(",");
+  let decimalSep: "," | "." | null = null;
+  if (hasDot && hasComma) {
+    decimalSep = cleaned.lastIndexOf(",") > cleaned.lastIndexOf(".") ? "," : ".";
+  } else if (hasComma && !hasDot) {
+    const parts = cleaned.split(",");
+    decimalSep = parts[parts.length - 1].length <= 2 ? "," : null;
+  } else if (hasDot && !hasComma) {
+    const parts = cleaned.split(".");
+    decimalSep = parts[parts.length - 1].length <= 2 ? "." : null;
+  }
+  let normalized = cleaned;
+  if (decimalSep) {
+    const thousand = decimalSep === "," ? /\./g : /,/g;
+    normalized = normalized.replace(thousand, "").replace(decimalSep, ".");
+  } else {
+    normalized = normalized.replace(/[.,]/g, "");
+  }
   const value = Number.parseFloat(normalized);
   return Number.isFinite(value) ? value : null;
 };


### PR DESCRIPTION
## Summary
- add Bootstrap 5 assets and switch layout to grid-based controls
- enable column sorting in flat and aggregated tables
- tidy styles to rely on Bootstrap

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68c6170df32083329faded7222909793