### PR TITLE
Refactor tradeup builder hook into modular helpers

### DIFF
--- a/client/src/modules/tradeups/TradeupBuilder.tsx
+++ b/client/src/modules/tradeups/TradeupBuilder.tsx
@@ -1,4 +1,10 @@
 import React from "react";
+import TradeupSummary from "./components/TradeupSummary";
+import CollectionSelectorSection from "./components/CollectionSelectorSection";
+import TargetSelectionSection from "./components/TargetSelectionSection";
+import InputsTableSection from "./components/InputsTableSection";
+import FloatlessAnalysisSection from "./components/FloatlessAnalysisSection";
+import ResultsSection from "./components/ResultsSection";
 import useTradeupBuilder from "./hooks/useTradeupBuilder";
 import "./TradeupBuilder.css";
 
@@ -6,40 +12,6 @@ import "./TradeupBuilder.css";
  * Основной компонент-конструктор. Комбинирует хук useTradeupBuilder и отображает все шаги:
  * загрузку коллекций из Steam, выбор целевого скина, заполнение входов и показ результатов.
  */
-
-/**
- * Приводит число к строке с фиксированным количеством знаков после запятой.
- * Используется для аккуратного отображения денежных значений и float-значений.
- */
-const formatNumber = (value: number, digits = 2) =>
-  Number.isFinite(value) ? value.toFixed(digits) : "—";
-
-/**
- * Преобразует вероятность в строку процента с двумя знаками после запятой.
- */
-const formatPercent = (value: number) =>
-  Number.isFinite(value) ? `${(value * 100).toFixed(2)}%` : "—";
-
-const EXTERIOR_SHORT: Record<string, string> = {
-  "Factory New": "FN",
-  "Minimal Wear": "MW",
-  "Field-Tested": "FT",
-  "Well-Worn": "WW",
-  "Battle-Scarred": "BS",
-};
-
-/** Сокращает название экстерьера до двухбуквенного обозначения. */
-const shortExterior = (exterior: string) => EXTERIOR_SHORT[exterior] ?? exterior;
-
-/** Порядок отображения экстерьеров от лучших к худшим. */
-const WEAR_ORDER = [
-  "Factory New",
-  "Minimal Wear",
-  "Field-Tested",
-  "Well-Worn",
-  "Battle-Scarred",
-] as const;
-
 export default function TradeupBuilder() {
   const {
     steamCollections,
@@ -83,424 +55,58 @@ export default function TradeupBuilder() {
             Подберите 10 входов, выберите целевые коллекции и рассчитайте ожидаемое значение.
           </p>
         </div>
-        <div className="tradeup-summary card bg-secondary-subtle text-dark p-3">
-          <div className="fw-semibold">Текущий ввод</div>
-          <div>Средний float: <strong>{formatNumber(averageFloat, 5)}</strong></div>
-          <div>Суммарно (buyer): <strong>${formatNumber(totalBuyerCost)}</strong></div>
-          <div>Суммарно (net): <strong>${formatNumber(totalNetCost)}</strong></div>
-          <div>
-            Комиссия:{" "}
-            <input
-              type="number"
-              min={0}
-              step={0.1}
-              className="form-control form-control-sm d-inline-block w-auto ms-2"
-              value={buyerFeePercent}
-              onChange={(event) => setBuyerFeePercent(Number(event.target.value) || 0)}
-            />
-            % (коэффициент {buyerToNetRate.toFixed(3)})
-          </div>
-        </div>
+        <TradeupSummary
+          averageFloat={averageFloat}
+          totalBuyerCost={totalBuyerCost}
+          totalNetCost={totalNetCost}
+          buyerFeePercent={buyerFeePercent}
+          buyerToNetRate={buyerToNetRate}
+          onBuyerFeeChange={(value) => setBuyerFeePercent(value)}
+        />
       </div>
 
       <hr className="border-secondary" />
 
-      {/* Шаг 1: выбираем коллекцию и смотрим подсказки по float-диапазонам. */}
-      <section>
-        <h3 className="h5">1. Выбор коллекции</h3>
-        <div className="d-flex flex-wrap gap-2 align-items-center mb-2">
-          <button
-            type="button"
-            className="btn btn-outline-light btn-sm"
-            onClick={() => loadSteamCollections()}
-            disabled={loadingSteamCollections}
-          >
-            {loadingSteamCollections ? "Загрузка…" : "Get all collections"}
-          </button>
-          {steamCollections.length === 0 && !loadingSteamCollections && (
-            <span className="text-muted small">Нажмите кнопку, чтобы получить список коллекций.</span>
-          )}
-        </div>
-        {steamCollectionError && <div className="text-danger mb-2">{steamCollectionError}</div>}
-        {steamCollections.length > 0 && (
-          <div className="tradeup-collections-list">
-            {steamCollections.map((collection) => {
-              const isActive = collection.tag === activeCollectionTag;
-              const supported = Boolean(collection.collectionId);
-              return (
-                <button
-                  type="button"
-                  key={collection.tag}
-                  className={`btn btn-sm ${isActive ? "btn-primary" : "btn-outline-light"}`}
-                  onClick={() => selectCollection(collection.tag)}
-                >
-                  {collection.name}
-                  {!supported && <span className="ms-2 badge text-bg-warning">нет float</span>}
-                </button>
-              );
-            })}
-          </div>
-        )}
-        {selectedCollectionDetails.length > 0 && (
-          <div className="mt-3">
-            <div className="fw-semibold">Диапазоны float целей</div>
-            <div className="tradeup-hints">
-              {selectedCollectionDetails.map((collection) => (
-                <div key={collection!.id} className="tradeup-hint card bg-secondary-subtle text-dark p-2">
-                  <div className="fw-semibold">{collection!.name}</div>
-                  <ul className="mb-0 small">
-                    {collection!.covert.map((skin) => (
-                      <li key={skin.baseName}>
-                        {skin.baseName}: {skin.minFloat.toFixed(3)} – {skin.maxFloat.toFixed(3)}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
-      </section>
+      <CollectionSelectorSection
+        steamCollections={steamCollections}
+        loadSteamCollections={loadSteamCollections}
+        loadingSteamCollections={loadingSteamCollections}
+        steamCollectionError={steamCollectionError}
+        activeCollectionTag={activeCollectionTag}
+        selectCollection={selectCollection}
+        selectedCollectionDetails={selectedCollectionDetails}
+      />
 
       <hr className="border-secondary" />
 
-      {/* Шаг 2: выбираем конкретный Covert-результат и подтягиваем доступные входы. */}
-      <section>
-        <h3 className="h5">2. Целевой скин</h3>
-        {!activeCollectionTag && (
-          <div className="text-muted">Сначала выберите коллекцию.</div>
-        )}
-        {targetsError && <div className="text-danger">{targetsError}</div>}
-        {loadingTargets && <div className="text-muted">Загрузка скинов…</div>}
-        {activeCollectionTag && !loadingTargets && collectionTargets.length === 0 && !targetsError && (
-          <div className="text-muted">Для этой коллекции не найдены Covert-скины.</div>
-        )}
-        {collectionTargets.length > 0 && (
-          <div className="tradeup-targets">
-            {collectionTargets.map((target) => (
-              <div key={target.baseName} className="tradeup-target card bg-secondary-subtle text-dark p-2">
-                <div className="fw-semibold">{target.baseName}</div>
-                <div className="tradeup-target-exteriors d-flex flex-wrap gap-2 mt-2">
-                  {target.exteriors.map((option) => {
-                    const isSelected =
-                      selectedTarget?.collectionTag === activeCollectionTag &&
-                      selectedTarget?.marketHashName === option.marketHashName;
-                    const floatHint =
-                      option.minFloat != null && option.maxFloat != null
-                        ? `${option.minFloat.toFixed(3)}-${option.maxFloat.toFixed(3)}`
-                        : null;
-                    return (
-                      <button
-                        type="button"
-                        key={option.marketHashName}
-                        className={`btn btn-sm ${isSelected ? "btn-primary" : "btn-outline-dark"}`}
-                        onClick={() => {
-                          if (activeCollectionTag) {
-                            selectTarget(activeCollectionTag, target.baseName, option);
-                          }
-                        }}
-                      >
-                        {shortExterior(option.exterior)}
-                        {floatHint && <span className="ms-1 small">({floatHint})</span>}
-                        {option.price != null && (
-                          <span className="ms-1 small text-muted">${formatNumber(option.price)}</span>
-                        )}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-        {inputsLoading && <div className="text-muted mt-2">Подбор входов…</div>}
-        {inputsError && <div className="text-danger mt-2">{inputsError}</div>}
-      </section>
+      <TargetSelectionSection
+        activeCollectionTag={activeCollectionTag}
+        collectionTargets={collectionTargets}
+        loadingTargets={loadingTargets}
+        targetsError={targetsError}
+        selectedTarget={selectedTarget}
+        selectTarget={selectTarget}
+        inputsLoading={inputsLoading}
+        inputsError={inputsError}
+      />
 
       <hr className="border-secondary" />
 
-      {/* Шаг 3: управляем входами и запускаем перерасчёт. */}
-      <section>
-        <h3 className="h5">3. Слот входа</h3>
-        <div className="table-responsive">
-          <table className="table table-dark table-sm align-middle tradeup-table">
-            <thead>
-              <tr>
-                <th>#</th>
-                <th>market_hash_name</th>
-                <th>Коллекция</th>
-                <th>Float</th>
-                <th>Buyer $</th>
-                <th>Net $ (после комиссии)</th>
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((row, index) => {
-                const buyerPrice = Number.parseFloat(row.buyerPrice);
-                const netPrice = Number.isFinite(buyerPrice)
-                  ? buyerPrice / buyerToNetRate
-                  : NaN;
-                return (
-                  <tr key={index}>
-                    <td>{index + 1}</td>
-                    <td>
-                      <input
-                        type="text"
-                        className="form-control form-control-sm"
-                        value={row.marketHashName}
-                        onChange={(event) => updateRow(index, { marketHashName: event.target.value })}
-                      />
-                    </td>
-                    <td>
-                      <select
-                        className="form-select form-select-sm"
-                        value={row.collectionId}
-                        onChange={(event) => updateRow(index, { collectionId: event.target.value })}
-                      >
-                        <option value="">—</option>
-                        {collectionOptions.map((option) => (
-                          <option key={option.value} value={option.value}>
-                            {option.label}
-                            {!option.supported ? " (нет float)" : ""}
-                          </option>
-                        ))}
-                      </select>
-                    </td>
-                    <td>
-                      <input
-                        type="number"
-                        step="0.0001"
-                        min="0"
-                        max="1"
-                        className="form-control form-control-sm"
-                        value={row.float}
-                        onChange={(event) => updateRow(index, { float: event.target.value })}
-                      />
-                    </td>
-                    <td>
-                      <input
-                        type="number"
-                        min="0"
-                        step="0.01"
-                        className="form-control form-control-sm"
-                        value={row.buyerPrice}
-                        onChange={(event) => updateRow(index, { buyerPrice: event.target.value })}
-                      />
-                    </td>
-                    <td>{Number.isFinite(netPrice) ? `$${netPrice.toFixed(2)}` : "—"}</td>
-                  </tr>
-                );
-              })}
-            </tbody>
-          </table>
-        </div>
-        <div className="d-flex flex-wrap gap-2">
-          <button
-            type="button"
-            className="btn btn-outline-info btn-sm"
-            onClick={() => autofillPrices()}
-            disabled={priceLoading}
-          >
-            {priceLoading ? "Загрузка цен…" : "Подтянуть buyer-цены"}
-          </button>
-          <button
-            type="button"
-            className="btn btn-primary btn-sm"
-            onClick={() => calculate()}
-            disabled={calculating}
-          >
-            {calculating ? "Расчёт…" : "Рассчитать ожидаемое значение (EV)"}
-          </button>
-        </div>
-        {calculationError && <div className="text-danger mt-2">{calculationError}</div>}
-      </section>
+      <InputsTableSection
+        rows={rows}
+        collectionOptions={collectionOptions}
+        buyerToNetRate={buyerToNetRate}
+        updateRow={updateRow}
+        autofillPrices={autofillPrices}
+        priceLoading={priceLoading}
+        calculate={calculate}
+        calculating={calculating}
+        calculationError={calculationError}
+      />
 
-      <section className="mt-4">
-        <h3 className="h5">3a. Оценка без float (robust / expected)</h3>
-        {floatlessAnalysis.issues.length > 0 && (
-          <div className="alert alert-warning mb-3">
-            <div className="fw-semibold">Нужно поправить входы:</div>
-            <ul className="mb-0">
-              {floatlessAnalysis.issues.map((issue) => (
-                <li key={issue}>{issue}</li>
-              ))}
-            </ul>
-          </div>
-        )}
-        {floatlessAnalysis.ready && floatlessAnalysis.inputRange && (
-          <>
-            <div className="card bg-secondary-subtle text-dark p-3 mb-3">
-              <div>
-                Диапазон среднего float:{" "}
-                <strong>
-                  {floatlessAnalysis.inputRange.min.toFixed(3)} – {floatlessAnalysis.inputRange.max.toFixed(3)}
-                </strong>
-              </div>
-              <div>
-                Рецепт:{" "}
-                {WEAR_ORDER.filter((exterior) => floatlessAnalysis.wearCounts[exterior])
-                  .map((exterior) => `${shortExterior(exterior)}×${floatlessAnalysis.wearCounts[exterior]}`)
-                  .join(", ") || "—"}
-              </div>
-              <div>
-                Робастная чистая прибыль (минимум):{" "}
-                <strong>
-                  {floatlessAnalysis.robustOutcomeNet != null
-                    ? `$${formatNumber(floatlessAnalysis.robustOutcomeNet)}`
-                    : "—"}
-                </strong>
-                {floatlessAnalysis.robustEV != null && (
-                  <span className="ms-2">
-                    Ожидаемое значение (EV):{" "}
-                    <strong
-                      className={floatlessAnalysis.robustEV >= 0 ? "text-success" : "text-danger"}
-                    >
-                      ${formatNumber(floatlessAnalysis.robustEV)}
-                    </strong>
-                  </span>
-                )}
-              </div>
-              <div>
-                Ожидаемая чистая прибыль:{" "}
-                <strong>
-                  {floatlessAnalysis.expectedOutcomeNet != null
-                    ? `$${formatNumber(floatlessAnalysis.expectedOutcomeNet)}`
-                    : "—"}
-                </strong>
-                {floatlessAnalysis.expectedEV != null && (
-                  <span className="ms-2">
-                    Ожидаемое значение (EV):{" "}
-                    <strong
-                      className={floatlessAnalysis.expectedEV >= 0 ? "text-success" : "text-danger"}
-                    >
-                      ${formatNumber(floatlessAnalysis.expectedEV)}
-                    </strong>
-                  </span>
-                )}
-                <span className="ms-2 text-muted">
-                  покрытие цен: {formatPercent(floatlessAnalysis.expectedCoverage)}
-                </span>
-              </div>
-            </div>
+      <FloatlessAnalysisSection floatlessAnalysis={floatlessAnalysis} />
 
-            <div className="table-responsive">
-              <table className="table table-dark table-sm align-middle">
-                <thead>
-                  <tr>
-                    <th>Covert</th>
-                    <th>Вероятность</th>
-                    <th>Проекция float</th>
-                    <th>Возможные wear</th>
-                    <th>Робастная чистая прибыль</th>
-                    <th>Ожидаемая чистая прибыль</th>
-                    <th>Покрытие</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {floatlessAnalysis.outcomes.map((outcome) => {
-                    const expectedConditional =
-                      outcome.expectedNetContribution != null && outcome.expectedProbabilityCovered > 0
-                        ? outcome.expectedNetContribution / outcome.expectedProbabilityCovered
-                        : null;
-                    return (
-                      <tr key={outcome.baseName}>
-                        <td>{outcome.baseName}</td>
-                        <td>{formatPercent(outcome.probability)}</td>
-                        <td>
-                          {outcome.projectedRange.min.toFixed(3)} – {outcome.projectedRange.max.toFixed(3)}
-                        </td>
-                        <td>
-                          <ul className="mb-0 small">
-                            {outcome.exteriors.map((option) => (
-                              <li key={option.marketHashName}>
-                                {shortExterior(option.exterior)}:{" "}
-                                {option.probability != null ? formatPercent(option.probability) : "—"}
-                                {", net "}
-                                {option.netPrice != null ? `$${formatNumber(option.netPrice)}` : "—"}
-                              </li>
-                            ))}
-                          </ul>
-                        </td>
-                        <td>
-                          {outcome.robustNet != null
-                            ? `$${formatNumber(outcome.robustNet)}`
-                            : "—"}
-                        </td>
-                        <td>
-                          {expectedConditional != null
-                            ? `$${formatNumber(expectedConditional)}`
-                            : "—"}
-                        </td>
-                        <td>{formatPercent(outcome.expectedProbabilityCovered)}</td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-          </>
-        )}
-      </section>
-
-      {/* Шаг 4: отображаем итоговую экономику и вероятности. */}
-      {calculation && (
-        <section className="mt-4">
-          <h3 className="h5">4. Результаты</h3>
-          <div className="tradeup-results card bg-secondary-subtle text-dark p-3">
-            <div>
-              Ожидаемый возврат после комиссии (net): <strong>${formatNumber(calculation.totalOutcomeNet)}</strong>
-            </div>
-            <div>
-              Ожидаемое значение (EV):{" "}
-              <strong className={calculation.expectedValue >= 0 ? "text-success" : "text-danger"}>
-                ${formatNumber(calculation.expectedValue)}
-              </strong>
-            </div>
-            <div>Допустимый бюджет на слот: <strong>${formatNumber(calculation.maxBudgetPerSlot)}</strong></div>
-            <div>Шанс плюса: <strong>{formatPercent(calculation.positiveOutcomeProbability)}</strong></div>
-          </div>
-
-          {calculation.warnings.length > 0 && (
-            <div className="alert alert-warning mt-3 mb-0">
-              <div className="fw-semibold">Предупреждения</div>
-              <ul className="mb-0">
-                {calculation.warnings.map((warning) => (
-                  <li key={warning}>{warning}</li>
-                ))}
-              </ul>
-            </div>
-          )}
-
-          <div className="table-responsive mt-3">
-            <table className="table table-dark table-sm align-middle">
-              <thead>
-                <tr>
-                  <th>Результат</th>
-                  <th>Коллекция</th>
-                  <th>Float</th>
-                  <th>Wear</th>
-                  <th>Buyer $</th>
-                  <th>Net $ (после комиссии)</th>
-                  <th>Вероятность</th>
-                </tr>
-              </thead>
-              <tbody>
-                {calculation.outcomes.map((outcome) => (
-                  <tr key={`${outcome.collectionId}-${outcome.baseName}`}>
-                    <td>{`${outcome.baseName} (${outcome.exterior})`}</td>
-                    <td>{outcome.collectionName}</td>
-                    <td>{outcome.rollFloat.toFixed(5)}</td>
-                    <td>{outcome.exterior}</td>
-                    <td>{outcome.buyerPrice != null ? `$${formatNumber(outcome.buyerPrice)}` : "—"}</td>
-                    <td>{outcome.netPrice != null ? `$${formatNumber(outcome.netPrice)}` : "—"}</td>
-                    <td>{formatPercent(outcome.probability)}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </section>
-      )}
+      {calculation && <ResultsSection calculation={calculation} />}
     </div>
   );
 }

--- a/client/src/modules/tradeups/components/CollectionSelectorSection.tsx
+++ b/client/src/modules/tradeups/components/CollectionSelectorSection.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import type { SteamCollectionSummary, TradeupCollection } from "../services/api";
+
+interface CollectionSelectorSectionProps {
+  steamCollections: SteamCollectionSummary[];
+  loadSteamCollections: () => void | Promise<void>;
+  loadingSteamCollections: boolean;
+  steamCollectionError: string | null;
+  activeCollectionTag: string | null;
+  selectCollection: (tag: string) => void;
+  selectedCollectionDetails: TradeupCollection[];
+}
+
+export default function CollectionSelectorSection({
+  steamCollections,
+  loadSteamCollections,
+  loadingSteamCollections,
+  steamCollectionError,
+  activeCollectionTag,
+  selectCollection,
+  selectedCollectionDetails,
+}: CollectionSelectorSectionProps) {
+  return (
+    <section>
+      <h3 className="h5">1. Выбор коллекции</h3>
+      <div className="d-flex flex-wrap gap-2 align-items-center mb-2">
+        <button
+          type="button"
+          className="btn btn-outline-light btn-sm"
+          onClick={() => loadSteamCollections()}
+          disabled={loadingSteamCollections}
+        >
+          {loadingSteamCollections ? "Загрузка…" : "Get all collections"}
+        </button>
+        {steamCollections.length === 0 && !loadingSteamCollections && (
+          <span className="text-muted small">Нажмите кнопку, чтобы получить список коллекций.</span>
+        )}
+      </div>
+      {steamCollectionError && <div className="text-danger mb-2">{steamCollectionError}</div>}
+      {steamCollections.length > 0 && (
+        <div className="tradeup-collections-list">
+          {steamCollections.map((collection) => {
+            const isActive = collection.tag === activeCollectionTag;
+            const supported = Boolean(collection.collectionId);
+            return (
+              <button
+                type="button"
+                key={collection.tag}
+                className={`btn btn-sm ${isActive ? "btn-primary" : "btn-outline-light"}`}
+                onClick={() => selectCollection(collection.tag)}
+              >
+                {collection.name}
+                {!supported && <span className="ms-2 badge text-bg-warning">нет float</span>}
+              </button>
+            );
+          })}
+        </div>
+      )}
+      {selectedCollectionDetails.length > 0 && (
+        <div className="mt-3">
+          <div className="fw-semibold">Диапазоны float целей</div>
+          <div className="tradeup-hints">
+            {selectedCollectionDetails.map((collection) => (
+              <div key={collection.id} className="tradeup-hint card bg-secondary-subtle text-dark p-2">
+                <div className="fw-semibold">{collection.name}</div>
+                <ul className="mb-0 small">
+                  {collection.covert.map((skin) => (
+                    <li key={skin.baseName}>
+                      {skin.baseName}: {skin.minFloat.toFixed(3)} – {skin.maxFloat.toFixed(3)}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/client/src/modules/tradeups/components/FloatlessAnalysisSection.tsx
+++ b/client/src/modules/tradeups/components/FloatlessAnalysisSection.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import type { FloatlessAnalysisResult } from "../hooks/useTradeupBuilder";
+import { formatNumber, formatPercent } from "../utils/format";
+import { shortExterior, WEAR_ORDER } from "../utils/wear";
+
+interface FloatlessAnalysisSectionProps {
+  floatlessAnalysis: FloatlessAnalysisResult;
+}
+
+export default function FloatlessAnalysisSection({
+  floatlessAnalysis,
+}: FloatlessAnalysisSectionProps) {
+  return (
+    <section className="mt-4">
+      <h3 className="h5">3a. Оценка без float (robust / expected)</h3>
+      {floatlessAnalysis.issues.length > 0 && (
+        <div className="alert alert-warning mb-3">
+          <div className="fw-semibold">Нужно поправить входы:</div>
+          <ul className="mb-0">
+            {floatlessAnalysis.issues.map((issue) => (
+              <li key={issue}>{issue}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {floatlessAnalysis.ready && floatlessAnalysis.inputRange && (
+        <>
+          <div className="card bg-secondary-subtle text-dark p-3 mb-3">
+            <div>
+              Диапазон среднего float:{" "}
+              <strong>
+                {floatlessAnalysis.inputRange.min.toFixed(3)} – {floatlessAnalysis.inputRange.max.toFixed(3)}
+              </strong>
+            </div>
+            <div>
+              Рецепт:{" "}
+              {WEAR_ORDER.filter((exterior) => floatlessAnalysis.wearCounts[exterior])
+                .map((exterior) => `${shortExterior(exterior)}×${floatlessAnalysis.wearCounts[exterior]}`)
+                .join(", ") || "—"}
+            </div>
+            <div>
+              Робастная чистая прибыль (минимум):{" "}
+              <strong>
+                {floatlessAnalysis.robustOutcomeNet != null
+                  ? `$${formatNumber(floatlessAnalysis.robustOutcomeNet)}`
+                  : "—"}
+              </strong>
+              {floatlessAnalysis.robustEV != null && (
+                <span className="ms-2">
+                  Ожидаемое значение (EV):{" "}
+                  <strong className={floatlessAnalysis.robustEV >= 0 ? "text-success" : "text-danger"}>
+                    ${formatNumber(floatlessAnalysis.robustEV)}
+                  </strong>
+                </span>
+              )}
+            </div>
+            <div>
+              Ожидаемая чистая прибыль:{" "}
+              <strong>
+                {floatlessAnalysis.expectedOutcomeNet != null
+                  ? `$${formatNumber(floatlessAnalysis.expectedOutcomeNet)}`
+                  : "—"}
+              </strong>
+              {floatlessAnalysis.expectedEV != null && (
+                <span className="ms-2">
+                  Ожидаемое значение (EV):{" "}
+                  <strong className={floatlessAnalysis.expectedEV >= 0 ? "text-success" : "text-danger"}>
+                    ${formatNumber(floatlessAnalysis.expectedEV)}
+                  </strong>
+                </span>
+              )}
+              <span className="ms-2 text-muted">
+                покрытие цен: {formatPercent(floatlessAnalysis.expectedCoverage)}
+              </span>
+            </div>
+          </div>
+
+          <div className="table-responsive">
+            <table className="table table-dark table-sm align-middle">
+              <thead>
+                <tr>
+                  <th>Covert</th>
+                  <th>Вероятность</th>
+                  <th>Проекция float</th>
+                  <th>Возможные wear</th>
+                  <th>Робастная чистая прибыль</th>
+                  <th>Ожидаемая чистая прибыль</th>
+                  <th>Покрытие</th>
+                </tr>
+              </thead>
+              <tbody>
+                {floatlessAnalysis.outcomes.map((outcome) => {
+                  const expectedConditional =
+                    outcome.expectedNetContribution != null && outcome.expectedProbabilityCovered > 0
+                      ? outcome.expectedNetContribution / outcome.expectedProbabilityCovered
+                      : null;
+                  return (
+                    <tr key={outcome.baseName}>
+                      <td>{outcome.baseName}</td>
+                      <td>{formatPercent(outcome.probability)}</td>
+                      <td>
+                        {outcome.projectedRange.min.toFixed(3)} – {outcome.projectedRange.max.toFixed(3)}
+                      </td>
+                      <td>
+                        <ul className="mb-0 small">
+                          {outcome.exteriors.map((option) => (
+                            <li key={option.marketHashName}>
+                              {shortExterior(option.exterior)}:{" "}
+                              {option.probability != null ? formatPercent(option.probability) : "—"}
+                              {", net "}
+                              {option.netPrice != null ? `$${formatNumber(option.netPrice)}` : "—"}
+                            </li>
+                          ))}
+                        </ul>
+                      </td>
+                      <td>
+                        {outcome.robustNet != null ? `$${formatNumber(outcome.robustNet)}` : "—"}
+                      </td>
+                      <td>
+                        {expectedConditional != null ? `$${formatNumber(expectedConditional)}` : "—"}
+                      </td>
+                      <td>{formatPercent(outcome.expectedProbabilityCovered)}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/client/src/modules/tradeups/components/InputsTableSection.tsx
+++ b/client/src/modules/tradeups/components/InputsTableSection.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import type { CollectionSelectOption, TradeupInputFormRow } from "../hooks/useTradeupBuilder";
+
+interface InputsTableSectionProps {
+  rows: TradeupInputFormRow[];
+  collectionOptions: CollectionSelectOption[];
+  buyerToNetRate: number;
+  updateRow: (index: number, patch: Partial<TradeupInputFormRow>) => void;
+  autofillPrices: () => void | Promise<void>;
+  priceLoading: boolean;
+  calculate: () => void | Promise<void>;
+  calculating: boolean;
+  calculationError: string | null;
+}
+
+export default function InputsTableSection({
+  rows,
+  collectionOptions,
+  buyerToNetRate,
+  updateRow,
+  autofillPrices,
+  priceLoading,
+  calculate,
+  calculating,
+  calculationError,
+}: InputsTableSectionProps) {
+  return (
+    <section>
+      <h3 className="h5">3. Слот входа</h3>
+      <div className="table-responsive">
+        <table className="table table-dark table-sm align-middle tradeup-table">
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>market_hash_name</th>
+              <th>Коллекция</th>
+              <th>Float</th>
+              <th>Buyer $</th>
+              <th>Net $ (после комиссии)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, index) => {
+              const buyerPrice = Number.parseFloat(row.buyerPrice);
+              const netPrice = Number.isFinite(buyerPrice) ? buyerPrice / buyerToNetRate : NaN;
+              return (
+                <tr key={index}>
+                  <td>{index + 1}</td>
+                  <td>
+                    <input
+                      type="text"
+                      className="form-control form-control-sm"
+                      value={row.marketHashName}
+                      onChange={(event) => updateRow(index, { marketHashName: event.target.value })}
+                    />
+                  </td>
+                  <td>
+                    <select
+                      className="form-select form-select-sm"
+                      value={row.collectionId}
+                      onChange={(event) => updateRow(index, { collectionId: event.target.value })}
+                    >
+                      <option value="">—</option>
+                      {collectionOptions.map((option) => (
+                        <option key={option.value} value={option.value}>
+                          {option.label}
+                          {!option.supported ? " (нет float)" : ""}
+                        </option>
+                      ))}
+                    </select>
+                  </td>
+                  <td>
+                    <input
+                      type="number"
+                      step="0.0001"
+                      min="0"
+                      max="1"
+                      className="form-control form-control-sm"
+                      value={row.float}
+                      onChange={(event) => updateRow(index, { float: event.target.value })}
+                    />
+                  </td>
+                  <td>
+                    <input
+                      type="number"
+                      min="0"
+                      step="0.01"
+                      className="form-control form-control-sm"
+                      value={row.buyerPrice}
+                      onChange={(event) => updateRow(index, { buyerPrice: event.target.value })}
+                    />
+                  </td>
+                  <td>{Number.isFinite(netPrice) ? `$${netPrice.toFixed(2)}` : "—"}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      <div className="d-flex flex-wrap gap-2">
+        <button
+          type="button"
+          className="btn btn-outline-info btn-sm"
+          onClick={() => autofillPrices()}
+          disabled={priceLoading}
+        >
+          {priceLoading ? "Загрузка цен…" : "Подтянуть buyer-цены"}
+        </button>
+        <button
+          type="button"
+          className="btn btn-primary btn-sm"
+          onClick={() => calculate()}
+          disabled={calculating}
+        >
+          {calculating ? "Расчёт…" : "Рассчитать ожидаемое значение (EV)"}
+        </button>
+      </div>
+      {calculationError && <div className="text-danger mt-2">{calculationError}</div>}
+    </section>
+  );
+}

--- a/client/src/modules/tradeups/components/ResultsSection.tsx
+++ b/client/src/modules/tradeups/components/ResultsSection.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import type { TradeupCalculationResponse } from "../services/api";
+import { formatNumber, formatPercent } from "../utils/format";
+
+interface ResultsSectionProps {
+  calculation: TradeupCalculationResponse;
+}
+
+export default function ResultsSection({ calculation }: ResultsSectionProps) {
+  return (
+    <section className="mt-4">
+      <h3 className="h5">4. Результаты</h3>
+      <div className="tradeup-results card bg-secondary-subtle text-dark p-3">
+        <div>
+          Ожидаемый возврат после комиссии (net): <strong>${formatNumber(calculation.totalOutcomeNet)}</strong>
+        </div>
+        <div>
+          Ожидаемое значение (EV):{" "}
+          <strong className={calculation.expectedValue >= 0 ? "text-success" : "text-danger"}>
+            ${formatNumber(calculation.expectedValue)}
+          </strong>
+        </div>
+        <div>Допустимый бюджет на слот: <strong>${formatNumber(calculation.maxBudgetPerSlot)}</strong></div>
+        <div>Шанс плюса: <strong>{formatPercent(calculation.positiveOutcomeProbability)}</strong></div>
+      </div>
+
+      {calculation.warnings.length > 0 && (
+        <div className="alert alert-warning mt-3 mb-0">
+          <div className="fw-semibold">Предупреждения</div>
+          <ul className="mb-0">
+            {calculation.warnings.map((warning) => (
+              <li key={warning}>{warning}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="table-responsive mt-3">
+        <table className="table table-dark table-sm align-middle">
+          <thead>
+            <tr>
+              <th>Результат</th>
+              <th>Коллекция</th>
+              <th>Float</th>
+              <th>Wear</th>
+              <th>Buyer $</th>
+              <th>Net $ (после комиссии)</th>
+              <th>Вероятность</th>
+            </tr>
+          </thead>
+          <tbody>
+            {calculation.outcomes.map((outcome) => (
+              <tr key={`${outcome.collectionId}-${outcome.baseName}`}>
+                <td>{`${outcome.baseName} (${outcome.exterior})`}</td>
+                <td>{outcome.collectionName}</td>
+                <td>{outcome.rollFloat.toFixed(5)}</td>
+                <td>{outcome.exterior}</td>
+                <td>{outcome.buyerPrice != null ? `$${formatNumber(outcome.buyerPrice)}` : "—"}</td>
+                <td>{outcome.netPrice != null ? `$${formatNumber(outcome.netPrice)}` : "—"}</td>
+                <td>{formatPercent(outcome.probability)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/client/src/modules/tradeups/components/TargetSelectionSection.tsx
+++ b/client/src/modules/tradeups/components/TargetSelectionSection.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import type {
+  CollectionTargetExterior,
+  CollectionTargetSummary,
+} from "../services/api";
+import type { SelectedTarget } from "../hooks/useTradeupBuilder";
+import { formatNumber } from "../utils/format";
+import { shortExterior } from "../utils/wear";
+
+interface TargetSelectionSectionProps {
+  activeCollectionTag: string | null;
+  collectionTargets: CollectionTargetSummary[];
+  loadingTargets: boolean;
+  targetsError: string | null;
+  selectedTarget: SelectedTarget | null;
+  selectTarget: (
+    collectionTag: string,
+    baseName: string,
+    option: CollectionTargetExterior,
+  ) => void;
+  inputsLoading: boolean;
+  inputsError: string | null;
+}
+
+export default function TargetSelectionSection({
+  activeCollectionTag,
+  collectionTargets,
+  loadingTargets,
+  targetsError,
+  selectedTarget,
+  selectTarget,
+  inputsLoading,
+  inputsError,
+}: TargetSelectionSectionProps) {
+  return (
+    <section>
+      <h3 className="h5">2. Целевой скин</h3>
+      {!activeCollectionTag && <div className="text-muted">Сначала выберите коллекцию.</div>}
+      {targetsError && <div className="text-danger">{targetsError}</div>}
+      {loadingTargets && <div className="text-muted">Загрузка скинов…</div>}
+      {activeCollectionTag && !loadingTargets && collectionTargets.length === 0 && !targetsError && (
+        <div className="text-muted">Для этой коллекции не найдены Covert-скины.</div>
+      )}
+      {collectionTargets.length > 0 && (
+        <div className="tradeup-targets">
+          {collectionTargets.map((target) => (
+            <div key={target.baseName} className="tradeup-target card bg-secondary-subtle text-dark p-2">
+              <div className="fw-semibold">{target.baseName}</div>
+              <div className="tradeup-target-exteriors d-flex flex-wrap gap-2 mt-2">
+                {target.exteriors.map((option) => {
+                  const isSelected =
+                    selectedTarget?.collectionTag === activeCollectionTag &&
+                    selectedTarget?.marketHashName === option.marketHashName;
+                  const floatHint =
+                    option.minFloat != null && option.maxFloat != null
+                      ? `${option.minFloat.toFixed(3)}-${option.maxFloat.toFixed(3)}`
+                      : null;
+                  return (
+                    <button
+                      type="button"
+                      key={option.marketHashName}
+                      className={`btn btn-sm ${isSelected ? "btn-primary" : "btn-outline-dark"}`}
+                      onClick={() => {
+                        if (activeCollectionTag) {
+                          selectTarget(activeCollectionTag, target.baseName, option);
+                        }
+                      }}
+                    >
+                      {shortExterior(option.exterior)}
+                      {floatHint && <span className="ms-1 small">({floatHint})</span>}
+                      {option.price != null && (
+                        <span className="ms-1 small text-muted">${formatNumber(option.price)}</span>
+                      )}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+      {inputsLoading && <div className="text-muted mt-2">Подбор входов…</div>}
+      {inputsError && <div className="text-danger mt-2">{inputsError}</div>}
+    </section>
+  );
+}

--- a/client/src/modules/tradeups/components/TradeupSummary.tsx
+++ b/client/src/modules/tradeups/components/TradeupSummary.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { formatNumber } from "../utils/format";
+
+interface TradeupSummaryProps {
+  averageFloat: number;
+  totalBuyerCost: number;
+  totalNetCost: number;
+  buyerFeePercent: number;
+  buyerToNetRate: number;
+  onBuyerFeeChange: (value: number) => void;
+}
+
+export default function TradeupSummary({
+  averageFloat,
+  totalBuyerCost,
+  totalNetCost,
+  buyerFeePercent,
+  buyerToNetRate,
+  onBuyerFeeChange,
+}: TradeupSummaryProps) {
+  return (
+    <div className="tradeup-summary card bg-secondary-subtle text-dark p-3">
+      <div className="fw-semibold">Текущий ввод</div>
+      <div>Средний float: <strong>{formatNumber(averageFloat, 5)}</strong></div>
+      <div>Суммарно (buyer): <strong>${formatNumber(totalBuyerCost)}</strong></div>
+      <div>Суммарно (net): <strong>${formatNumber(totalNetCost)}</strong></div>
+      <div>
+        Комиссия:{" "}
+        <input
+          type="number"
+          min={0}
+          step={0.1}
+          className="form-control form-control-sm d-inline-block w-auto ms-2"
+          value={buyerFeePercent}
+          onChange={(event) => onBuyerFeeChange(Number(event.target.value) || 0)}
+        />
+        % (коэффициент {buyerToNetRate.toFixed(3)})
+      </div>
+    </div>
+  );
+}

--- a/client/src/modules/tradeups/hooks/constants.ts
+++ b/client/src/modules/tradeups/hooks/constants.ts
@@ -1,0 +1,19 @@
+import type { Exterior } from "../../skins/services/types";
+
+export const EXTERIOR_FLOAT_RANGES: Record<Exterior, { min: number; max: number }> = {
+  "Factory New": { min: 0, max: 0.07 },
+  "Minimal Wear": { min: 0.07, max: 0.15 },
+  "Field-Tested": { min: 0.15, max: 0.38 },
+  "Well-Worn": { min: 0.38, max: 0.45 },
+  "Battle-Scarred": { min: 0.45, max: 1 },
+};
+
+export const WEAR_BUCKET_SEQUENCE: Array<{ exterior: Exterior; min: number; max: number }> = [
+  { exterior: "Factory New", min: 0, max: 0.07 },
+  { exterior: "Minimal Wear", min: 0.07, max: 0.15 },
+  { exterior: "Field-Tested", min: 0.15, max: 0.38 },
+  { exterior: "Well-Worn", min: 0.38, max: 0.45 },
+  { exterior: "Battle-Scarred", min: 0.45, max: 1 },
+];
+
+export const STEAM_TAG_VALUE_PREFIX = "steam-tag:";

--- a/client/src/modules/tradeups/hooks/floatlessAnalysis.ts
+++ b/client/src/modules/tradeups/hooks/floatlessAnalysis.ts
@@ -1,0 +1,336 @@
+import type { Exterior } from "../../skins/services/types";
+import { parseExterior } from "../../skins/services/utils";
+import type { CollectionTargetSummary, TradeupCollection } from "../services/api";
+import { EXTERIOR_FLOAT_RANGES, WEAR_BUCKET_SEQUENCE } from "./constants";
+import { clampFloat } from "./helpers";
+import type {
+  FloatlessAnalysisResult,
+  FloatlessOutcomeExterior,
+  FloatlessOutcomeSummary,
+  RowResolution,
+  SelectedTarget,
+} from "./types";
+
+interface FloatlessAnalysisParams {
+  rowResolution: RowResolution;
+  activeTargets: CollectionTargetSummary[];
+  catalogMap: Map<string, TradeupCollection>;
+  selectedTarget: SelectedTarget | null;
+  targetPriceOverrides: Record<string, number>;
+  buyerToNetRate: number;
+  totalNetCost: number;
+}
+
+type WearSlot = { exterior: Exterior; bucket: { min: number; max: number } };
+
+export const evaluateFloatlessTradeup = ({
+  rowResolution,
+  activeTargets,
+  catalogMap,
+  selectedTarget,
+  targetPriceOverrides,
+  buyerToNetRate,
+  totalNetCost,
+}: FloatlessAnalysisParams): FloatlessAnalysisResult => {
+  const issues: string[] = [];
+  const wearCounts: Partial<Record<Exterior, number>> = {};
+
+  if (!rowResolution.rows.length) {
+    issues.push("Нужно добавить входы для оценки");
+    return {
+      ready: false,
+      issues,
+      inputRange: null,
+      wearCounts,
+      outcomes: [],
+      robustOutcomeNet: null,
+      expectedOutcomeNet: null,
+      robustEV: null,
+      expectedEV: null,
+      expectedCoverage: 0,
+    };
+  }
+
+  if (rowResolution.rows.length !== 10) {
+    issues.push("Нужно ровно 10 входов для trade-up");
+  }
+
+  if (rowResolution.unresolvedNames.length) {
+    issues.push(
+      `Не удалось определить коллекцию для: ${rowResolution.unresolvedNames
+        .map((name) => `"${name}"`)
+        .join(", ")}`,
+    );
+  }
+
+  if (rowResolution.hasMultipleCollections) {
+    issues.push("Нужно использовать предметы из одной коллекции");
+  }
+
+  const resolvedCollectionId = rowResolution.resolvedCollectionId;
+  if (!resolvedCollectionId) {
+    issues.push("Не выбрана целевая коллекция для расчёта");
+  }
+
+  if (!activeTargets.length) {
+    issues.push("Нет данных о выходах для выбранной коллекции");
+  }
+
+  const wearSlots = rowResolution.rows.map<WearSlot | null>((row) => {
+    const exterior = parseExterior(row.marketHashName);
+    const bucket = EXTERIOR_FLOAT_RANGES[exterior];
+    if (!bucket) return null;
+    wearCounts[exterior] = (wearCounts[exterior] ?? 0) + 1;
+    return { exterior, bucket };
+  });
+
+  if (wearSlots.some((slot) => slot == null)) {
+    issues.push("Не удалось распознать wear некоторых входов по market_hash_name");
+  }
+
+  if (issues.length > 0 || !resolvedCollectionId) {
+    return {
+      ready: false,
+      issues,
+      inputRange: null,
+      wearCounts,
+      outcomes: [],
+      robustOutcomeNet: null,
+      expectedOutcomeNet: null,
+      robustEV: null,
+      expectedEV: null,
+      expectedCoverage: 0,
+    };
+  }
+
+  const validSlots = wearSlots.filter((slot): slot is WearSlot => Boolean(slot));
+  const totalSlots = validSlots.length;
+  const minSum = validSlots.reduce((sum, slot) => sum + slot.bucket.min, 0);
+  const maxSum = validSlots.reduce((sum, slot) => sum + slot.bucket.max, 0);
+  const inputRange = {
+    min: clampFloat(minSum / Math.max(totalSlots, 1)),
+    max: clampFloat(maxSum / Math.max(totalSlots, 1)),
+  };
+
+  const collectionProbability = rowResolution.rows.length
+    ? (rowResolution.collectionCounts.get(resolvedCollectionId) ?? 0) / rowResolution.rows.length
+    : 0;
+
+  const baseCount = activeTargets.length;
+  const baseProbability = baseCount > 0 ? collectionProbability / baseCount : 0;
+
+  const catalogEntry = catalogMap.get(resolvedCollectionId) ?? null;
+
+  const outcomes: FloatlessOutcomeSummary[] = [];
+  let robustOutcomeNet: number | null = 0;
+  let expectedOutcomeNet: number | null = 0;
+  let expectedCoverage = 0;
+  let hasRobustGap = false;
+  let hasExpectedData = false;
+
+  let selectedTargetCoverage: {
+    probability: number | null;
+    projectedRange: { min: number; max: number };
+    dominantExterior: Exterior | null;
+  } | null = null;
+
+  for (const target of activeTargets) {
+    const exteriorEntries = target.exteriors;
+    let minFloat: number | null = null;
+    let maxFloat: number | null = null;
+    for (const exterior of exteriorEntries) {
+      if (exterior.minFloat != null) {
+        minFloat = minFloat == null ? exterior.minFloat : Math.min(minFloat, exterior.minFloat);
+      }
+      if (exterior.maxFloat != null) {
+        maxFloat = maxFloat == null ? exterior.maxFloat : Math.max(maxFloat, exterior.maxFloat);
+      }
+    }
+
+    if (minFloat == null || maxFloat == null) {
+      const fallback = catalogEntry?.covert.find((entry) => entry.baseName === target.baseName);
+      if (fallback) {
+        minFloat = fallback.minFloat;
+        maxFloat = fallback.maxFloat;
+      }
+    }
+
+    if (minFloat == null || maxFloat == null) {
+      minFloat = 0;
+      maxFloat = 1;
+    }
+
+    if (minFloat > maxFloat) {
+      [minFloat, maxFloat] = [maxFloat, minFloat];
+    }
+
+    const projectedMin = clampFloat(minFloat + (maxFloat - minFloat) * inputRange.min);
+    const projectedMax = clampFloat(minFloat + (maxFloat - minFloat) * inputRange.max);
+    const normalizedMin = Math.min(projectedMin, projectedMax);
+    const normalizedMax = Math.max(projectedMin, projectedMax);
+    const rangeWidth = Math.max(0, normalizedMax - normalizedMin);
+
+    const potential = WEAR_BUCKET_SEQUENCE.map((bucket) => {
+      const targetExterior = exteriorEntries.find((entry) => entry.exterior === bucket.exterior);
+      if (!targetExterior) return null;
+      const matchesSelected =
+        !!selectedTarget &&
+        target.baseName === selectedTarget.baseName &&
+        (targetExterior.marketHashName === selectedTarget.marketHashName ||
+          targetExterior.exterior === selectedTarget.exterior);
+      const min = Math.max(bucket.min, normalizedMin);
+      const max = Math.min(bucket.max, normalizedMax);
+      const width = Math.max(0, max - min);
+      const containsPoint = rangeWidth === 0 && normalizedMin >= bucket.min && normalizedMin <= bucket.max;
+      if (width <= 0 && !containsPoint && !matchesSelected) return null;
+      const buyerPrice =
+        targetExterior.price ?? targetPriceOverrides[targetExterior.marketHashName] ?? null;
+      const netPrice = buyerPrice == null ? null : buyerPrice / buyerToNetRate;
+      return {
+        exterior: bucket.exterior,
+        width,
+        containsPoint,
+        matchesSelected,
+        buyerPrice,
+        netPrice,
+        marketHashName: targetExterior.marketHashName,
+      };
+    }).filter((entry): entry is {
+      exterior: Exterior;
+      width: number;
+      containsPoint: boolean;
+      matchesSelected: boolean;
+      buyerPrice: number | null;
+      netPrice: number | null;
+      marketHashName: string;
+    } => entry != null);
+
+    let widthSum = 0;
+    for (const entry of potential) {
+      widthSum += entry.width;
+    }
+
+    const denominator = rangeWidth > 0 ? widthSum || rangeWidth : 1;
+    const exteriors: FloatlessOutcomeExterior[] = [];
+    let robustNet: number | null = null;
+    let expectedContribution: number | null = null;
+    let expectedProbabilityCovered = 0;
+    let selectedProbability: number | null = null;
+    let dominantExterior: { exterior: Exterior; probability: number } | null = null;
+
+    for (const entry of potential) {
+      let probability: number | null = null;
+      if (rangeWidth === 0) {
+        probability = entry.containsPoint ? 1 : 0;
+      } else if (denominator > 0) {
+        probability = entry.width / denominator;
+      }
+
+      exteriors.push({
+        exterior: entry.exterior,
+        probability,
+        buyerPrice: entry.buyerPrice,
+        netPrice: entry.netPrice,
+        marketHashName: entry.marketHashName,
+      });
+
+      if (probability != null && entry.netPrice != null) {
+        if (robustNet == null || entry.netPrice < robustNet) {
+          robustNet = entry.netPrice;
+        }
+        expectedContribution = (expectedContribution ?? 0) + entry.netPrice * probability;
+        expectedProbabilityCovered += probability;
+      }
+
+      if (probability != null) {
+        if (
+          dominantExterior == null ||
+          probability > dominantExterior.probability ||
+          (probability === dominantExterior.probability && entry.exterior === selectedTarget?.exterior)
+        ) {
+          dominantExterior = { exterior: entry.exterior, probability };
+        }
+
+        if (
+          entry.matchesSelected &&
+          target.baseName === selectedTarget?.baseName &&
+          (selectedProbability == null || probability > selectedProbability)
+        ) {
+          selectedProbability = probability;
+        }
+      }
+    }
+
+    if (robustNet == null) {
+      hasRobustGap = true;
+    }
+
+    if (expectedContribution != null && expectedProbabilityCovered > 0) {
+      hasExpectedData = true;
+      expectedOutcomeNet = (expectedOutcomeNet ?? 0) + expectedContribution * baseProbability;
+      expectedCoverage += expectedProbabilityCovered * baseProbability;
+    }
+
+    if (robustNet != null) {
+      robustOutcomeNet = (robustOutcomeNet ?? 0) + robustNet * baseProbability;
+    }
+
+    outcomes.push({
+      baseName: target.baseName,
+      probability: baseProbability,
+      projectedRange: { min: normalizedMin, max: normalizedMax },
+      exteriors,
+      robustNet,
+      expectedNetContribution: expectedContribution,
+      expectedProbabilityCovered,
+    });
+
+    if (selectedTarget && target.baseName === selectedTarget.baseName) {
+      selectedTargetCoverage = {
+        probability: selectedProbability,
+        projectedRange: { min: normalizedMin, max: normalizedMax },
+        dominantExterior: dominantExterior?.exterior ?? null,
+      };
+    }
+  }
+
+  if (hasRobustGap) {
+    robustOutcomeNet = null;
+  }
+
+  if (!hasExpectedData) {
+    expectedOutcomeNet = null;
+    expectedCoverage = 0;
+  }
+
+  const robustEV = robustOutcomeNet == null ? null : robustOutcomeNet - totalNetCost;
+  const expectedEV = expectedOutcomeNet == null ? null : expectedOutcomeNet - totalNetCost;
+
+  if (
+    selectedTarget &&
+    selectedTargetCoverage &&
+    (selectedTargetCoverage.probability == null || selectedTargetCoverage.probability <= 0)
+  ) {
+    const fallbackExteriorLabel = selectedTargetCoverage.dominantExterior
+      ? `${selectedTargetCoverage.dominantExterior}`
+      : "другой экстерьер";
+    issues.push(
+      `Выбранный экстерьер ${selectedTarget.exterior} (${selectedTarget.baseName}) ` +
+        `не попадает в прогнозируемый диапазон (${selectedTargetCoverage.projectedRange.min.toFixed(5)}–${selectedTargetCoverage.projectedRange.max.toFixed(5)}). ` +
+        `Ожидаемый результат: ${fallbackExteriorLabel}.`,
+    );
+  }
+
+  return {
+    ready: issues.length === 0,
+    issues,
+    inputRange,
+    wearCounts,
+    outcomes,
+    robustOutcomeNet,
+    expectedOutcomeNet,
+    robustEV,
+    expectedEV,
+    expectedCoverage,
+  };
+};

--- a/client/src/modules/tradeups/hooks/helpers.ts
+++ b/client/src/modules/tradeups/hooks/helpers.ts
@@ -1,0 +1,37 @@
+import type { Exterior } from "../../skins/services/types";
+import { EXTERIOR_FLOAT_RANGES, STEAM_TAG_VALUE_PREFIX } from "./constants";
+import type { TradeupInputFormRow } from "./types";
+
+export const makeEmptyRow = (): TradeupInputFormRow => ({
+  marketHashName: "",
+  collectionId: "",
+  float: "",
+  buyerPrice: "",
+});
+
+export const createInitialRows = () => Array.from({ length: 10 }, makeEmptyRow);
+
+export const clampFloat = (value: number) => Math.min(1, Math.max(0, value));
+
+export const exteriorMidpoint = (exterior: Exterior) => {
+  const range = EXTERIOR_FLOAT_RANGES[exterior];
+  if (!range) return null;
+  return (range.min + range.max) / 2;
+};
+
+export const formatFloatValue = (value: number | null | undefined) =>
+  value == null ? "" : clampFloat(value).toFixed(5);
+
+export const buildCollectionSelectValue = (
+  collectionId?: string | null,
+  collectionTag?: string | null,
+) => {
+  if (collectionId) return collectionId;
+  if (collectionTag) return `${STEAM_TAG_VALUE_PREFIX}${collectionTag}`;
+  return "";
+};
+
+export const readTagFromCollectionValue = (value: string) =>
+  value.startsWith(STEAM_TAG_VALUE_PREFIX)
+    ? value.slice(STEAM_TAG_VALUE_PREFIX.length)
+    : null;

--- a/client/src/modules/tradeups/hooks/rowPlanning.ts
+++ b/client/src/modules/tradeups/hooks/rowPlanning.ts
@@ -1,0 +1,258 @@
+import type { Exterior } from "../../skins/services/types";
+import type { CollectionInputSummary } from "../services/api";
+import { EXTERIOR_FLOAT_RANGES, WEAR_BUCKET_SEQUENCE } from "./constants";
+import {
+  buildCollectionSelectValue,
+  clampFloat,
+  exteriorMidpoint,
+  formatFloatValue,
+  makeEmptyRow,
+} from "./helpers";
+import type { TradeupInputFormRow } from "./types";
+
+interface PlanRowsOptions {
+  target?: {
+    exterior: Exterior;
+    minFloat?: number | null;
+    maxFloat?: number | null;
+  };
+}
+
+interface PlanRowsParams {
+  collectionTag: string;
+  collectionId: string | null;
+  selectedCollectionId: string | null;
+  inputs: CollectionInputSummary[];
+  options?: PlanRowsOptions;
+}
+
+interface PlannedRowsResult {
+  rows: TradeupInputFormRow[];
+  missingNames: string[];
+}
+
+const desiredFloatFromTarget = (options?: PlanRowsOptions) => {
+  const target = options?.target;
+  if (!target) return null;
+  if (target.minFloat != null && target.maxFloat != null && target.maxFloat > target.minFloat) {
+    return clampFloat((target.minFloat + target.maxFloat) / 2);
+  }
+  const midpoint = exteriorMidpoint(target.exterior);
+  return midpoint != null ? clampFloat(midpoint) : null;
+};
+
+const resolveTargetRange = (options?: PlanRowsOptions) => {
+  const target = options?.target;
+  if (!target) return null;
+
+  const bucket = EXTERIOR_FLOAT_RANGES[target.exterior];
+  const clampToBounds = (value: number) => clampFloat(value);
+
+  const resolveCatalogRange = () => {
+    if (target.minFloat == null && target.maxFloat == null) return null;
+    const min = target.minFloat != null ? clampToBounds(target.minFloat) : 0;
+    const max = target.maxFloat != null ? clampToBounds(target.maxFloat) : 1;
+    const normalizedMin = Math.min(min, max);
+    const normalizedMax = Math.max(min, max);
+    return { min: normalizedMin, max: normalizedMax };
+  };
+
+  if (bucket) {
+    const bucketMin = clampToBounds(bucket.min);
+    const bucketMax = clampToBounds(bucket.max);
+    const catalogRange = resolveCatalogRange();
+    const min = Math.max(bucketMin, catalogRange?.min ?? bucketMin);
+    const max = Math.min(bucketMax, catalogRange?.max ?? bucketMax);
+    if (min <= max) {
+      return { min, max };
+    }
+    return { min: bucketMin, max: bucketMax };
+  }
+
+  return resolveCatalogRange();
+};
+
+const sortInputsForPlanning = (
+  inputs: CollectionInputSummary[],
+  desiredFloat: number | null,
+): CollectionInputSummary[] => {
+  const priceOf = (entry: CollectionInputSummary) =>
+    typeof entry.price === "number" ? entry.price : Number.POSITIVE_INFINITY;
+
+  const fallbackCompare = (a: CollectionInputSummary, b: CollectionInputSummary) => {
+    if (desiredFloat != null) {
+      const aMid = exteriorMidpoint(a.exterior) ?? desiredFloat;
+      const bMid = exteriorMidpoint(b.exterior) ?? desiredFloat;
+      const diff = Math.abs(aMid - desiredFloat) - Math.abs(bMid - desiredFloat);
+      if (diff !== 0) return diff;
+    }
+    return a.marketHashName.localeCompare(b.marketHashName, "ru");
+  };
+
+  const sortableInputs = [...inputs];
+  sortableInputs.sort((a, b) => {
+    const priceDiff = priceOf(a) - priceOf(b);
+    if (priceDiff !== 0) {
+      return priceDiff;
+    }
+    return fallbackCompare(a, b);
+  });
+  return sortableInputs;
+};
+
+export const planRowsForCollection = ({
+  collectionTag,
+  collectionId,
+  selectedCollectionId,
+  inputs,
+  options,
+}: PlanRowsParams): PlannedRowsResult => {
+  const effectiveCollectionValue = buildCollectionSelectValue(
+    collectionId ?? selectedCollectionId,
+    collectionTag,
+  );
+
+  const targetRange = resolveTargetRange(options);
+  const desiredFloat = targetRange
+    ? clampFloat((targetRange.min + targetRange.max) / 2)
+    : desiredFloatFromTarget(options);
+
+  const sortedInputs = sortInputsForPlanning(inputs, desiredFloat);
+
+  const inputsByExterior = sortedInputs.reduce((map, input) => {
+    const current = map.get(input.exterior) ?? [];
+    current.push(input);
+    map.set(input.exterior, current);
+    return map;
+  }, new Map<Exterior, CollectionInputSummary[]>());
+
+  const plannedInputs: CollectionInputSummary[] = [];
+
+  if (targetRange) {
+    const projectedBuckets = WEAR_BUCKET_SEQUENCE.map((bucket) => {
+      const bucketRange = EXTERIOR_FLOAT_RANGES[bucket.exterior];
+      if (!bucketRange) return null;
+      const min = Math.max(bucketRange.min, targetRange.min);
+      const max = Math.min(bucketRange.max, targetRange.max);
+      const width = Math.max(0, max - min);
+      const containsPoint =
+        targetRange.min === targetRange.max &&
+        targetRange.min >= bucketRange.min &&
+        targetRange.min <= bucketRange.max;
+      const weight = width > 0 ? width : containsPoint ? 1e-6 : 0;
+      if (weight <= 0) return null;
+      return {
+        exterior: bucket.exterior,
+        weight,
+      };
+    }).filter((entry): entry is { exterior: Exterior; weight: number } => entry != null);
+
+    if (projectedBuckets.length > 0) {
+      const totalWeight = projectedBuckets.reduce((sum, entry) => sum + entry.weight, 0);
+      const normalized = projectedBuckets.map((entry) => {
+        const exact = (entry.weight / totalWeight) * 10;
+        const count = Math.floor(exact);
+        const remainder = exact - count;
+        return { ...entry, count, remainder };
+      });
+
+      let assigned = normalized.reduce((sum, entry) => sum + entry.count, 0);
+      const deficit = 10 - assigned;
+      if (deficit > 0) {
+        normalized
+          .slice()
+          .sort((a, b) => b.remainder - a.remainder)
+          .slice(0, deficit)
+          .forEach((entry) => {
+            entry.count += 1;
+          });
+        assigned = normalized.reduce((sum, entry) => sum + entry.count, 0);
+      }
+
+      if (assigned > 10) {
+        normalized
+          .slice()
+          .sort((a, b) => a.remainder - b.remainder)
+          .slice(0, assigned - 10)
+          .forEach((entry) => {
+            if (entry.count > 0) {
+              entry.count -= 1;
+            }
+          });
+      }
+
+      for (const entry of normalized) {
+        if (entry.count <= 0) continue;
+        const pool = inputsByExterior.get(entry.exterior);
+        if (!pool || pool.length === 0) continue;
+        for (let i = 0; i < entry.count; i += 1) {
+          plannedInputs.push(pool[i % pool.length]);
+        }
+      }
+    }
+  }
+
+  if (plannedInputs.length < 10) {
+    for (let i = 0; plannedInputs.length < 10 && sortedInputs.length > 0; i += 1) {
+      plannedInputs.push(sortedInputs[i % sortedInputs.length]);
+    }
+  }
+
+  const trimmedPlan = plannedInputs.slice(0, 10);
+  const offsetStep = desiredFloat != null && trimmedPlan.length > 1 ? 0.00005 : 0;
+  const centerIndex = (trimmedPlan.length - 1) / 2;
+
+  const rows: TradeupInputFormRow[] = trimmedPlan.map((input, index) => {
+    const bucketRange = EXTERIOR_FLOAT_RANGES[input.exterior] ?? null;
+    const rowFloatRange = (() => {
+      if (!targetRange) {
+        return bucketRange;
+      }
+      if (!bucketRange) {
+        return targetRange;
+      }
+      const min = Math.max(bucketRange.min, targetRange.min);
+      const max = Math.min(bucketRange.max, targetRange.max);
+      if (min <= max) {
+        return { min, max };
+      }
+      return bucketRange;
+    })();
+
+    const clampWithinRowRange = (value: number) => {
+      const range = rowFloatRange ?? bucketRange ?? targetRange;
+      if (range) {
+        if (value < range.min) return clampFloat(range.min);
+        if (value > range.max) return clampFloat(range.max);
+        return clampFloat(value);
+      }
+      return clampFloat(value);
+    };
+
+    const rowMidpoint = rowFloatRange
+      ? (rowFloatRange.min + rowFloatRange.max) / 2
+      : bucketRange
+      ? (bucketRange.min + bucketRange.max) / 2
+      : null;
+    const baselineSource = desiredFloat ?? rowMidpoint ?? exteriorMidpoint(input.exterior) ?? null;
+    const baseline = baselineSource == null ? null : clampWithinRowRange(baselineSource);
+    const adjusted =
+      baseline == null
+        ? null
+        : clampWithinRowRange(baseline + offsetStep * (index - centerIndex));
+    return {
+      marketHashName: input.marketHashName,
+      collectionId: effectiveCollectionValue,
+      float: formatFloatValue(adjusted),
+      buyerPrice: input.price != null ? input.price.toFixed(2) : "",
+    };
+  });
+
+  while (rows.length < 10) rows.push(makeEmptyRow());
+
+  const missingNames = trimmedPlan
+    .filter((input) => input.price == null)
+    .map((input) => input.marketHashName);
+
+  return { rows, missingNames };
+};

--- a/client/src/modules/tradeups/hooks/rowResolution.ts
+++ b/client/src/modules/tradeups/hooks/rowResolution.ts
@@ -1,0 +1,110 @@
+import type { SteamCollectionSummary, TradeupCollection } from "../services/api";
+import { readTagFromCollectionValue } from "./helpers";
+import type {
+  CollectionValueMeta,
+  ParsedTradeupRow,
+  ResolvedTradeupRow,
+  RowResolution,
+} from "./types";
+
+interface ResolveRowsParams {
+  parsedRows: ParsedTradeupRow[];
+  selectedCollectionId: string | null;
+  collectionValueMeta: Map<string, CollectionValueMeta>;
+  steamCollectionsByTag: Map<string, SteamCollectionSummary>;
+  catalogMap: Map<string, TradeupCollection>;
+  collectionIdByTag: Map<string, string>;
+}
+
+export const resolveTradeupRows = ({
+  parsedRows,
+  selectedCollectionId,
+  collectionValueMeta,
+  steamCollectionsByTag,
+  catalogMap,
+  collectionIdByTag,
+}: ResolveRowsParams): RowResolution => {
+  if (!parsedRows.length) {
+    return {
+      rows: [],
+      unresolvedNames: [],
+      hasMultipleCollections: false,
+      resolvedCollectionId: selectedCollectionId ?? null,
+      collectionCounts: new Map(),
+    };
+  }
+
+  const rowsWithResolved: ResolvedTradeupRow[] = parsedRows.map((row) => {
+    const meta = collectionValueMeta.get(row.collectionId);
+    const fallbackTag = meta?.tag ?? readTagFromCollectionValue(row.collectionId);
+    const steamEntry = fallbackTag ? steamCollectionsByTag.get(fallbackTag) : undefined;
+
+    let resolvedId = meta?.collectionId ?? null;
+    let resolvedName = meta?.name ?? steamEntry?.name ?? null;
+
+    if (!resolvedId && row.collectionId && catalogMap.has(row.collectionId)) {
+      resolvedId = row.collectionId;
+    }
+
+    if (!resolvedId && fallbackTag) {
+      const cachedByTag = collectionIdByTag.get(fallbackTag);
+      if (cachedByTag) {
+        resolvedId = cachedByTag;
+      }
+    }
+
+    if (!resolvedId && steamEntry?.collectionId) {
+      resolvedId = steamEntry.collectionId;
+    }
+
+    if (!resolvedId && selectedCollectionId) {
+      resolvedId = selectedCollectionId;
+    }
+
+    if (!resolvedId && row.collectionId) {
+      resolvedId = row.collectionId;
+    }
+
+    if (!resolvedName && resolvedId) {
+      resolvedName = catalogMap.get(resolvedId)?.name ?? resolvedName;
+    }
+
+    if (!resolvedName && steamEntry?.name) {
+      resolvedName = steamEntry.name;
+    }
+
+    return {
+      ...row,
+      resolvedCollectionId: resolvedId,
+      resolvedCollectionName: resolvedName,
+      resolvedTag: fallbackTag,
+    };
+  });
+
+  const unresolvedRows = rowsWithResolved.filter((row) => !row.resolvedCollectionId);
+  const unresolvedNames = Array.from(
+    new Set(unresolvedRows.map((row) => row.resolvedCollectionName ?? row.collectionId ?? "неизвестно")),
+  );
+
+  const collectionCounts = new Map<string, number>();
+  for (const row of rowsWithResolved) {
+    if (!row.resolvedCollectionId) continue;
+    collectionCounts.set(row.resolvedCollectionId, (collectionCounts.get(row.resolvedCollectionId) ?? 0) + 1);
+  }
+
+  const resolvedIds = Array.from(collectionCounts.keys());
+  const hasMultipleCollections = resolvedIds.length > 1;
+
+  let resolvedCollectionId = selectedCollectionId ?? null;
+  if (!resolvedCollectionId && resolvedIds.length === 1) {
+    [resolvedCollectionId] = resolvedIds;
+  }
+
+  return {
+    rows: rowsWithResolved,
+    unresolvedNames,
+    hasMultipleCollections,
+    resolvedCollectionId,
+    collectionCounts,
+  };
+};

--- a/client/src/modules/tradeups/hooks/types.ts
+++ b/client/src/modules/tradeups/hooks/types.ts
@@ -1,0 +1,142 @@
+import type { Exterior } from "../../skins/services/types";
+import type {
+  CollectionInputSummary,
+  CollectionTargetsResponse,
+  TradeupCalculationResponse,
+  TradeupCollection,
+} from "../services/api";
+
+export interface TradeupInputFormRow {
+  marketHashName: string;
+  collectionId: string;
+  float: string;
+  buyerPrice: string;
+}
+
+export interface ParsedTradeupRow {
+  marketHashName: string;
+  collectionId: string;
+  float: number;
+  buyerPrice: number;
+}
+
+export interface CollectionSelectOption {
+  value: string;
+  label: string;
+  supported: boolean;
+}
+
+export interface CollectionValueMeta {
+  collectionId: string | null;
+  tag: string | null;
+  name: string;
+}
+
+export interface SelectedTarget {
+  collectionTag: string;
+  baseName: string;
+  exterior: Exterior;
+  marketHashName: string;
+  minFloat?: number;
+  maxFloat?: number;
+  price?: number | null;
+}
+
+export interface ResolvedTradeupRow {
+  marketHashName: string;
+  collectionId: string;
+  float: number;
+  buyerPrice: number;
+  resolvedCollectionId: string | null;
+  resolvedCollectionName: string | null;
+  resolvedTag: string | null;
+}
+
+export interface RowResolution {
+  rows: ResolvedTradeupRow[];
+  unresolvedNames: string[];
+  hasMultipleCollections: boolean;
+  resolvedCollectionId: string | null;
+  collectionCounts: Map<string, number>;
+}
+
+export interface FloatlessOutcomeExterior {
+  exterior: Exterior;
+  probability: number | null;
+  buyerPrice: number | null;
+  netPrice: number | null;
+  marketHashName: string;
+}
+
+export interface FloatlessOutcomeSummary {
+  baseName: string;
+  probability: number;
+  projectedRange: { min: number; max: number };
+  exteriors: FloatlessOutcomeExterior[];
+  robustNet: number | null;
+  expectedNetContribution: number | null;
+  expectedProbabilityCovered: number;
+}
+
+export interface FloatlessAnalysisResult {
+  ready: boolean;
+  issues: string[];
+  inputRange: { min: number; max: number } | null;
+  wearCounts: Partial<Record<Exterior, number>>;
+  outcomes: FloatlessOutcomeSummary[];
+  robustOutcomeNet: number | null;
+  expectedOutcomeNet: number | null;
+  robustEV: number | null;
+  expectedEV: number | null;
+  expectedCoverage: number;
+}
+
+export interface CollectionLookupContext {
+  catalogCollections: TradeupCollection[];
+  catalogMap: Map<string, TradeupCollection>;
+  steamCollections: Array<{ tag: string; name: string; collectionId: string | null }>;
+  steamCollectionsByTag: Map<string, { tag: string; name: string; collectionId: string | null }>;
+  targetsByCollection: Record<string, CollectionTargetsResponse>;
+  inputsByCollection: Record<
+    string,
+    { collectionId: string | null; collectionTag: string; inputs: CollectionInputSummary[] }
+  >;
+}
+
+export interface TradeupBuilderState {
+  catalogCollections: TradeupCollection[];
+  steamCollections: Array<{ tag: string; name: string; collectionId: string | null }>;
+  collectionOptions: CollectionSelectOption[];
+  loadSteamCollections: () => void | Promise<void>;
+  loadingSteamCollections: boolean;
+  steamCollectionError: string | null;
+  activeCollectionTag: string | null;
+  selectCollection: (tag: string) => void;
+  collectionTargets: CollectionTargetsResponse["targets"];
+  loadingTargets: boolean;
+  targetsError: string | null;
+  selectedTarget: SelectedTarget | null;
+  selectTarget: (
+    collectionTag: string,
+    baseName: string,
+    exterior: CollectionTargetsResponse["targets"][number]["exteriors"][number],
+  ) => void | Promise<void>;
+  inputsLoading: boolean;
+  inputsError: string | null;
+  rows: TradeupInputFormRow[];
+  updateRow: (index: number, patch: Partial<TradeupInputFormRow>) => void;
+  buyerFeePercent: number;
+  setBuyerFeePercent: React.Dispatch<React.SetStateAction<number>>;
+  buyerToNetRate: number;
+  averageFloat: number;
+  totalBuyerCost: number;
+  totalNetCost: number;
+  selectedCollectionDetails: TradeupCollection[];
+  autofillPrices: (namesOverride?: string[]) => Promise<void> | void;
+  priceLoading: boolean;
+  calculate: () => Promise<void>;
+  calculation: TradeupCalculationResponse | null;
+  calculating: boolean;
+  calculationError: string | null;
+  floatlessAnalysis: FloatlessAnalysisResult;
+}

--- a/client/src/modules/tradeups/hooks/useTradeupBuilder.ts
+++ b/client/src/modules/tradeups/hooks/useTradeupBuilder.ts
@@ -1,6 +1,4 @@
 import React from "react";
-import type { Exterior } from "../../skins/services/types";
-import { parseExterior } from "../../skins/services/utils";
 import {
   batchPriceOverview,
   fetchCollectionInputs,
@@ -15,158 +13,37 @@ import {
   type TradeupCalculationResponse,
   type TradeupCollection,
 } from "../services/api";
+import {
+  buildCollectionSelectValue,
+  createInitialRows,
+  readTagFromCollectionValue,
+} from "./helpers";
+import { evaluateFloatlessTradeup } from "./floatlessAnalysis";
+import { planRowsForCollection } from "./rowPlanning";
+import { resolveTradeupRows } from "./rowResolution";
+import type {
+  CollectionSelectOption,
+  CollectionValueMeta,
+  FloatlessAnalysisResult,
+  ParsedTradeupRow,
+  RowResolution,
+  SelectedTarget,
+  TradeupInputFormRow,
+} from "./types";
+
+export type {
+  TradeupInputFormRow,
+  CollectionSelectOption,
+  SelectedTarget,
+  FloatlessOutcomeExterior,
+  FloatlessOutcomeSummary,
+  FloatlessAnalysisResult,
+} from "./types";
 
 /**
  * Хук инкапсулирует весь state и бизнес-логику для TradeupBuilder:
  * загрузку справочников, выбор целей, управление входами и отправку расчёта на сервер.
  */
-
-export interface TradeupInputFormRow {
-  marketHashName: string;
-  /**
-   * Значение селекта коллекций. Может содержать как внутренний идентификатор коллекции,
-   * так и fallback на steam-tag (если float-справочник пока не знает эту коллекцию).
-   */
-  collectionId: string;
-  float: string;
-  buyerPrice: string;
-}
-
-/**
- * Создаёт пустую строку формы ввода trade-up'а.
- * Используется для инициализации и очистки таблицы.
- */
-const makeEmptyRow = (): TradeupInputFormRow => ({
-  marketHashName: "",
-  collectionId: "",
-  float: "",
-  buyerPrice: "",
-});
-
-/** Возвращает массив из десяти пустых строк формы. */
-const createInitialRows = () => Array.from({ length: 10 }, makeEmptyRow);
-
-const EXTERIOR_FLOAT_RANGES: Record<Exterior, { min: number; max: number }> = {
-  "Factory New": { min: 0, max: 0.07 },
-  "Minimal Wear": { min: 0.07, max: 0.15 },
-  "Field-Tested": { min: 0.15, max: 0.38 },
-  "Well-Worn": { min: 0.38, max: 0.45 },
-  "Battle-Scarred": { min: 0.45, max: 1 },
-};
-
-const WEAR_BUCKET_SEQUENCE: Array<{ exterior: Exterior; min: number; max: number }> = [
-  { exterior: "Factory New", min: 0, max: 0.07 },
-  { exterior: "Minimal Wear", min: 0.07, max: 0.15 },
-  { exterior: "Field-Tested", min: 0.15, max: 0.38 },
-  { exterior: "Well-Worn", min: 0.38, max: 0.45 },
-  { exterior: "Battle-Scarred", min: 0.45, max: 1 },
-];
-
-/** Ограничивает float-значение диапазоном [0, 1]. */
-const clampFloat = (value: number) => Math.min(1, Math.max(0, value));
-
-/** Возвращает середину стандартного диапазона для заданного экстерьера. */
-const exteriorMidpoint = (exterior: Exterior) => {
-  const range = EXTERIOR_FLOAT_RANGES[exterior];
-  if (!range) return null;
-  return (range.min + range.max) / 2;
-};
-
-/** Форматирует float для отображения в input (пустая строка для null/undefined). */
-const formatFloatValue = (value: number | null | undefined) =>
-  value == null ? "" : clampFloat(value).toFixed(5);
-
-const STEAM_TAG_VALUE_PREFIX = "steam-tag:";
-
-interface CollectionSelectOption {
-  value: string;
-  label: string;
-  supported: boolean;
-}
-
-/**
- * Строит значение для select'а коллекций. Предпочитает внутренний id,
- * но при его отсутствии использует steam-tag с префиксом.
- */
-const buildCollectionSelectValue = (
-  collectionId?: string | null,
-  collectionTag?: string | null,
-) => {
-  if (collectionId) return collectionId;
-  if (collectionTag) return `${STEAM_TAG_VALUE_PREFIX}${collectionTag}`;
-  return "";
-};
-
-/** Возвращает steam-tag из значения селекта, если он закодирован префиксом. */
-const readTagFromCollectionValue = (value: string) =>
-  value.startsWith(STEAM_TAG_VALUE_PREFIX)
-    ? value.slice(STEAM_TAG_VALUE_PREFIX.length)
-    : null;
-
-interface CollectionValueMeta {
-  collectionId: string | null;
-  tag: string | null;
-  name: string;
-}
-
-interface SelectedTarget {
-  collectionTag: string;
-  baseName: string;
-  exterior: Exterior;
-  marketHashName: string;
-  minFloat?: number;
-  maxFloat?: number;
-  price?: number | null;
-}
-
-interface ResolvedTradeupRow {
-  marketHashName: string;
-  collectionId: string;
-  float: number;
-  buyerPrice: number;
-  resolvedCollectionId: string | null;
-  resolvedCollectionName: string | null;
-  resolvedTag: string | null;
-}
-
-interface FloatlessOutcomeExterior {
-  exterior: Exterior;
-  probability: number | null;
-  buyerPrice: number | null;
-  netPrice: number | null;
-  marketHashName: string;
-}
-
-interface FloatlessOutcomeSummary {
-  baseName: string;
-  probability: number;
-  projectedRange: { min: number; max: number };
-  exteriors: FloatlessOutcomeExterior[];
-  robustNet: number | null;
-  expectedNetContribution: number | null;
-  expectedProbabilityCovered: number;
-}
-
-interface FloatlessAnalysisResult {
-  ready: boolean;
-  issues: string[];
-  inputRange: { min: number; max: number } | null;
-  wearCounts: Partial<Record<Exterior, number>>;
-  outcomes: FloatlessOutcomeSummary[];
-  robustOutcomeNet: number | null;
-  expectedOutcomeNet: number | null;
-  robustEV: number | null;
-  expectedEV: number | null;
-  expectedCoverage: number;
-}
-
-interface RowResolution {
-  rows: ResolvedTradeupRow[];
-  unresolvedNames: string[];
-  hasMultipleCollections: boolean;
-  resolvedCollectionId: string | null;
-  collectionCounts: Map<string, number>;
-}
 
 export default function useTradeupBuilder() {
   const [catalogCollections, setCatalogCollections] = React.useState<TradeupCollection[]>([]);
@@ -585,227 +462,22 @@ export default function useTradeupBuilder() {
       inputs: CollectionInputSummary[],
       options?: {
         target?: {
-          exterior: Exterior;
+          exterior: CollectionTargetExterior["exterior"];
           minFloat?: number | null;
           maxFloat?: number | null;
         };
       },
     ) => {
-      const effectiveCollectionValue = buildCollectionSelectValue(
-        collectionId ?? selectedCollectionId,
+      const { rows: plannedRows, missingNames } = planRowsForCollection({
         collectionTag,
-      );
-
-      const targetRange = (() => {
-        const target = options?.target;
-        if (!target) return null;
-
-        const bucket = EXTERIOR_FLOAT_RANGES[target.exterior];
-        const clampToBounds = (value: number) => clampFloat(value);
-
-        const resolveCatalogRange = () => {
-          if (target.minFloat == null && target.maxFloat == null) return null;
-          const min =
-            target.minFloat != null ? clampToBounds(target.minFloat) : 0;
-          const max =
-            target.maxFloat != null ? clampToBounds(target.maxFloat) : 1;
-          const normalizedMin = Math.min(min, max);
-          const normalizedMax = Math.max(min, max);
-          return { min: normalizedMin, max: normalizedMax };
-        };
-
-        if (bucket) {
-          const bucketMin = clampToBounds(bucket.min);
-          const bucketMax = clampToBounds(bucket.max);
-          const catalogRange = resolveCatalogRange();
-          const min = Math.max(bucketMin, catalogRange?.min ?? bucketMin);
-          const max = Math.min(bucketMax, catalogRange?.max ?? bucketMax);
-          if (min <= max) {
-            return { min, max };
-          }
-          return { min: bucketMin, max: bucketMax };
-        }
-
-        return resolveCatalogRange();
-      })();
-
-      const desiredFloat = (() => {
-        if (targetRange) {
-          return clampFloat((targetRange.min + targetRange.max) / 2);
-        }
-        const target = options?.target;
-        if (!target) return null;
-        if (target.minFloat != null && target.maxFloat != null && target.maxFloat > target.minFloat) {
-          return clampFloat((target.minFloat + target.maxFloat) / 2);
-        }
-        const midpoint = exteriorMidpoint(target.exterior);
-        return midpoint != null ? clampFloat(midpoint) : null;
-      })();
-
-      const sortedInputs = (() => {
-        const priceOf = (entry: CollectionInputSummary) =>
-          typeof entry.price === "number" ? entry.price : Number.POSITIVE_INFINITY;
-
-        const fallbackCompare = (a: CollectionInputSummary, b: CollectionInputSummary) => {
-          if (desiredFloat != null) {
-            const aMid = exteriorMidpoint(a.exterior) ?? desiredFloat;
-            const bMid = exteriorMidpoint(b.exterior) ?? desiredFloat;
-            const diff = Math.abs(aMid - desiredFloat) - Math.abs(bMid - desiredFloat);
-            if (diff !== 0) return diff;
-          }
-          return a.marketHashName.localeCompare(b.marketHashName, "ru");
-        };
-
-        const sortableInputs = [...inputs];
-        sortableInputs.sort((a, b) => {
-          const priceDiff = priceOf(a) - priceOf(b);
-          if (priceDiff !== 0) {
-            return priceDiff;
-          }
-          return fallbackCompare(a, b);
-        });
-        return sortableInputs;
-      })();
-
-      const inputsByExterior = sortedInputs.reduce((map, input) => {
-        const current = map.get(input.exterior) ?? [];
-        current.push(input);
-        map.set(input.exterior, current);
-        return map;
-      }, new Map<Exterior, CollectionInputSummary[]>());
-
-      // Сюда будем складывать 10 предполагаемых входов для таблицы.
-      const plannedInputs: CollectionInputSummary[] = [];
-
-      if (targetRange) {
-        const projectedBuckets = WEAR_BUCKET_SEQUENCE.map((bucket) => {
-          const bucketRange = EXTERIOR_FLOAT_RANGES[bucket.exterior];
-          if (!bucketRange) return null;
-          const min = Math.max(bucketRange.min, targetRange.min);
-          const max = Math.min(bucketRange.max, targetRange.max);
-          const width = Math.max(0, max - min);
-          const containsPoint =
-            targetRange.min === targetRange.max &&
-            targetRange.min >= bucketRange.min &&
-            targetRange.min <= bucketRange.max;
-          const weight = width > 0 ? width : containsPoint ? 1e-6 : 0;
-          if (weight <= 0) return null;
-          return {
-            exterior: bucket.exterior,
-            weight,
-          };
-        }).filter((entry): entry is { exterior: Exterior; weight: number } => entry != null);
-
-        if (projectedBuckets.length > 0) {
-          const totalWeight = projectedBuckets.reduce((sum, entry) => sum + entry.weight, 0);
-          const normalized = projectedBuckets.map((entry) => {
-            const exact = (entry.weight / totalWeight) * 10;
-            const count = Math.floor(exact);
-            const remainder = exact - count;
-            return { ...entry, count, remainder };
-          });
-
-          let assigned = normalized.reduce((sum, entry) => sum + entry.count, 0);
-          const deficit = 10 - assigned;
-          if (deficit > 0) {
-            normalized
-              .slice()
-              .sort((a, b) => b.remainder - a.remainder)
-              .slice(0, deficit)
-              .forEach((entry) => {
-                entry.count += 1;
-              });
-            assigned = normalized.reduce((sum, entry) => sum + entry.count, 0);
-          }
-
-          if (assigned > 10) {
-            normalized
-              .slice()
-              .sort((a, b) => a.remainder - b.remainder)
-              .slice(0, assigned - 10)
-              .forEach((entry) => {
-                if (entry.count > 0) {
-                  entry.count -= 1;
-                }
-              });
-          }
-
-          for (const entry of normalized) {
-            if (entry.count <= 0) continue;
-            const pool = inputsByExterior.get(entry.exterior);
-            if (!pool || pool.length === 0) continue;
-            for (let i = 0; i < entry.count; i += 1) {
-              plannedInputs.push(pool[i % pool.length]);
-            }
-          }
-        }
-      }
-
-      if (plannedInputs.length < 10) {
-        for (let i = 0; plannedInputs.length < 10 && sortedInputs.length > 0; i += 1) {
-          plannedInputs.push(sortedInputs[i % sortedInputs.length]);
-        }
-      }
-
-      const trimmedPlan = plannedInputs.slice(0, 10);
-      // Лёгкий offset помогает распределить float вокруг целевого значения.
-      const offsetStep = desiredFloat != null && trimmedPlan.length > 1 ? 0.00005 : 0;
-      const centerIndex = (trimmedPlan.length - 1) / 2;
-
-      const filledRows: TradeupInputFormRow[] = trimmedPlan.map((input, index) => {
-        const bucketRange = EXTERIOR_FLOAT_RANGES[input.exterior] ?? null;
-        // Итоговый диапазон для строки — пересечение выбранного таргета и бакета предмета.
-        const rowFloatRange = (() => {
-          if (!targetRange) {
-            return bucketRange;
-          }
-          if (!bucketRange) {
-            return targetRange;
-          }
-          const min = Math.max(bucketRange.min, targetRange.min);
-          const max = Math.min(bucketRange.max, targetRange.max);
-          if (min <= max) {
-            return { min, max };
-          }
-          return bucketRange;
-        })();
-
-        const clampWithinRowRange = (value: number) => {
-          const range = rowFloatRange ?? bucketRange ?? targetRange;
-          if (range) {
-            if (value < range.min) return clampFloat(range.min);
-            if (value > range.max) return clampFloat(range.max);
-            return clampFloat(value);
-          }
-          return clampFloat(value);
-        };
-
-        const rowMidpoint = rowFloatRange
-          ? (rowFloatRange.min + rowFloatRange.max) / 2
-          : bucketRange
-          ? (bucketRange.min + bucketRange.max) / 2
-          : null;
-        const baselineSource =
-          desiredFloat ?? rowMidpoint ?? exteriorMidpoint(input.exterior) ?? null;
-        const baseline =
-          baselineSource == null ? null : clampWithinRowRange(baselineSource);
-        const adjusted =
-          baseline == null
-            ? null
-            : clampWithinRowRange(baseline + offsetStep * (index - centerIndex));
-        return {
-          marketHashName: input.marketHashName,
-          collectionId: effectiveCollectionValue,
-          float: formatFloatValue(adjusted),
-          buyerPrice: input.price != null ? input.price.toFixed(2) : "",
-        };
+        collectionId,
+        selectedCollectionId,
+        inputs,
+        options,
       });
-      while (filledRows.length < 10) filledRows.push(makeEmptyRow());
-      setRows(filledRows);
 
-      const missingNames = trimmedPlan
-        .filter((input) => input.price == null)
-        .map((input) => input.marketHashName);
+      setRows(plannedRows);
+
       if (missingNames.length) {
         await autofillPrices(missingNames);
       }
@@ -906,101 +578,21 @@ export default function useTradeupBuilder() {
   }, [rows]);
 
   const rowResolution = React.useMemo<RowResolution>(() => {
-    if (!parsedRows.length) {
-      return {
-        rows: [],
-        unresolvedNames: [],
-        hasMultipleCollections: false,
-        resolvedCollectionId: selectedCollectionId ?? null,
-        collectionCounts: new Map(),
-      };
-    }
-
-    const rowsWithResolved: ResolvedTradeupRow[] = parsedRows.map((row) => {
-      const meta = collectionValueMeta.get(row.collectionId);
-      const fallbackTag = meta?.tag ?? readTagFromCollectionValue(row.collectionId);
-      const steamEntry = fallbackTag ? steamCollectionsByTag.get(fallbackTag) : undefined;
-
-      let resolvedId = meta?.collectionId ?? null;
-      let resolvedName = meta?.name ?? steamEntry?.name ?? null;
-
-      if (!resolvedId && row.collectionId && catalogMap.has(row.collectionId)) {
-        resolvedId = row.collectionId;
-      }
-
-      if (!resolvedId && fallbackTag) {
-        const cachedByTag = collectionIdByTag.get(fallbackTag);
-        if (cachedByTag) {
-          resolvedId = cachedByTag;
-        }
-      }
-
-      if (!resolvedId && steamEntry?.collectionId) {
-        resolvedId = steamEntry.collectionId;
-      }
-
-      if (!resolvedId && selectedCollectionId) {
-        resolvedId = selectedCollectionId;
-      }
-
-      if (!resolvedId && row.collectionId) {
-        resolvedId = row.collectionId;
-      }
-
-      if (!resolvedName && resolvedId) {
-        resolvedName = catalogMap.get(resolvedId)?.name ?? resolvedName;
-      }
-
-      if (!resolvedName && steamEntry?.name) {
-        resolvedName = steamEntry.name;
-      }
-
-      return {
-        ...row,
-        resolvedCollectionId: resolvedId,
-        resolvedCollectionName: resolvedName,
-        resolvedTag: fallbackTag,
-      };
+    return resolveTradeupRows({
+      parsedRows,
+      selectedCollectionId,
+      collectionValueMeta,
+      steamCollectionsByTag,
+      catalogMap,
+      collectionIdByTag,
     });
-
-    const unresolvedRows = rowsWithResolved.filter((row) => !row.resolvedCollectionId);
-    const unresolvedNames = Array.from(
-      new Set(
-        unresolvedRows.map((row) => row.resolvedCollectionName ?? row.collectionId ?? "неизвестно"),
-      ),
-    );
-
-    const collectionCounts = new Map<string, number>();
-    for (const row of rowsWithResolved) {
-      if (!row.resolvedCollectionId) continue;
-      collectionCounts.set(
-        row.resolvedCollectionId,
-        (collectionCounts.get(row.resolvedCollectionId) ?? 0) + 1,
-      );
-    }
-
-    const resolvedIds = Array.from(collectionCounts.keys());
-    const hasMultipleCollections = resolvedIds.length > 1;
-
-    let resolvedCollectionId = selectedCollectionId ?? null;
-    if (!resolvedCollectionId && resolvedIds.length === 1) {
-      [resolvedCollectionId] = resolvedIds;
-    }
-
-    return {
-      rows: rowsWithResolved,
-      unresolvedNames,
-      hasMultipleCollections,
-      resolvedCollectionId,
-      collectionCounts,
-    };
   }, [
     parsedRows,
-    catalogMap,
     collectionIdByTag,
     collectionValueMeta,
     selectedCollectionId,
     steamCollectionsByTag,
+    catalogMap,
   ]);
 
   /** Средний float по заполненным слотам. */
@@ -1025,316 +617,25 @@ export default function useTradeupBuilder() {
    * Возвращает как консервативные, так и ожидаемые метрики доходности.
    */
   const floatlessAnalysis = React.useMemo<FloatlessAnalysisResult>(() => {
-    const issues: string[] = [];
-    const wearCounts: Partial<Record<Exterior, number>> = {};
-
-    if (!rowResolution.rows.length) {
-      issues.push("Нужно добавить входы для оценки");
-      return {
-        ready: false,
-        issues,
-        inputRange: null,
-        wearCounts,
-        outcomes: [],
-        robustOutcomeNet: null,
-        expectedOutcomeNet: null,
-        robustEV: null,
-        expectedEV: null,
-        expectedCoverage: 0,
-      };
-    }
-
-    if (rowResolution.rows.length !== 10) {
-      issues.push("Нужно ровно 10 входов для trade-up");
-    }
-
-    if (rowResolution.unresolvedNames.length) {
-      issues.push(
-        `Не удалось определить коллекцию для: ${rowResolution.unresolvedNames
-          .map((name) => `"${name}"`)
-          .join(", ")}`,
-      );
-    }
-
-    if (rowResolution.hasMultipleCollections) {
-      issues.push("Нужно использовать предметы из одной коллекции");
-    }
-
-    const resolvedCollectionId = rowResolution.resolvedCollectionId;
-    if (!resolvedCollectionId) {
-      issues.push("Не выбрана целевая коллекция для расчёта");
-    }
-
-    if (!activeTargets.length) {
-      issues.push("Нет данных о выходах для выбранной коллекции");
-    }
-
-    const wearSlots = rowResolution.rows.map((row) => {
-      const exterior = parseExterior(row.marketHashName);
-      const bucket = EXTERIOR_FLOAT_RANGES[exterior];
-      if (!bucket) return null;
-      wearCounts[exterior] = (wearCounts[exterior] ?? 0) + 1;
-      return { exterior, bucket };
+    return evaluateFloatlessTradeup({
+      rowResolution,
+      activeTargets,
+      catalogMap,
+      selectedTarget,
+      targetPriceOverrides,
+      buyerToNetRate,
+      totalNetCost,
     });
-
-    if (wearSlots.some((slot) => slot == null)) {
-      issues.push("Не удалось распознать wear некоторых входов по market_hash_name");
-    }
-
-    if (issues.length > 0 || !resolvedCollectionId) {
-      return {
-        ready: false,
-        issues,
-        inputRange: null,
-        wearCounts,
-        outcomes: [],
-        robustOutcomeNet: null,
-        expectedOutcomeNet: null,
-        robustEV: null,
-        expectedEV: null,
-        expectedCoverage: 0,
-      };
-    }
-
-    const validSlots = wearSlots.filter((slot): slot is { exterior: Exterior; bucket: { min: number; max: number } } =>
-      Boolean(slot),
-    );
-    const totalSlots = validSlots.length;
-    const minSum = validSlots.reduce((sum, slot) => sum + slot.bucket.min, 0);
-    const maxSum = validSlots.reduce((sum, slot) => sum + slot.bucket.max, 0);
-    const inputRange = {
-      min: clampFloat(minSum / Math.max(totalSlots, 1)),
-      max: clampFloat(maxSum / Math.max(totalSlots, 1)),
-    };
-
-    const collectionProbability = rowResolution.rows.length
-      ? (rowResolution.collectionCounts.get(resolvedCollectionId) ?? 0) /
-        rowResolution.rows.length
-      : 0;
-
-    const baseCount = activeTargets.length;
-    const baseProbability = baseCount > 0 ? collectionProbability / baseCount : 0;
-
-    const catalogEntry = catalogMap.get(resolvedCollectionId) ?? null;
-
-    const outcomes: FloatlessOutcomeSummary[] = [];
-    let robustOutcomeNet: number | null = 0;
-    let expectedOutcomeNet: number | null = 0;
-    let expectedCoverage = 0;
-    let hasRobustGap = false;
-    let hasExpectedData = false;
-
-    let selectedTargetCoverage: {
-      probability: number | null;
-      projectedRange: { min: number; max: number };
-      dominantExterior: Exterior | null;
-    } | null = null;
-
-    for (const target of activeTargets) {
-      const exteriorEntries = target.exteriors;
-      let minFloat: number | null = null;
-      let maxFloat: number | null = null;
-      for (const exterior of exteriorEntries) {
-        if (exterior.minFloat != null) {
-          minFloat = minFloat == null ? exterior.minFloat : Math.min(minFloat, exterior.minFloat);
-        }
-        if (exterior.maxFloat != null) {
-          maxFloat = maxFloat == null ? exterior.maxFloat : Math.max(maxFloat, exterior.maxFloat);
-        }
-      }
-
-      if (minFloat == null || maxFloat == null) {
-        const fallback = catalogEntry?.covert.find((entry) => entry.baseName === target.baseName);
-        if (fallback) {
-          minFloat = fallback.minFloat;
-          maxFloat = fallback.maxFloat;
-        }
-      }
-
-      if (minFloat == null || maxFloat == null) {
-        minFloat = 0;
-        maxFloat = 1;
-      }
-
-      if (minFloat > maxFloat) {
-        [minFloat, maxFloat] = [maxFloat, minFloat];
-      }
-
-      const projectedMin = clampFloat(minFloat + (maxFloat - minFloat) * inputRange.min);
-      const projectedMax = clampFloat(minFloat + (maxFloat - minFloat) * inputRange.max);
-      const normalizedMin = Math.min(projectedMin, projectedMax);
-      const normalizedMax = Math.max(projectedMin, projectedMax);
-      const rangeWidth = Math.max(0, normalizedMax - normalizedMin);
-
-      const potential = WEAR_BUCKET_SEQUENCE.map((bucket) => {
-        const targetExterior = exteriorEntries.find((entry) => entry.exterior === bucket.exterior);
-        if (!targetExterior) return null;
-        const matchesSelected =
-          !!selectedTarget &&
-          target.baseName === selectedTarget.baseName &&
-          (targetExterior.marketHashName === selectedTarget.marketHashName ||
-            targetExterior.exterior === selectedTarget.exterior);
-        const min = Math.max(bucket.min, normalizedMin);
-        const max = Math.min(bucket.max, normalizedMax);
-        const width = Math.max(0, max - min);
-        const containsPoint =
-          rangeWidth === 0 && normalizedMin >= bucket.min && normalizedMin <= bucket.max;
-        if (width <= 0 && !containsPoint && !matchesSelected) return null;
-        const buyerPrice =
-          targetExterior.price ?? targetPriceOverrides[targetExterior.marketHashName] ?? null;
-        const netPrice = buyerPrice == null ? null : buyerPrice / buyerToNetRate;
-        return {
-          exterior: bucket.exterior,
-          width,
-          containsPoint,
-          matchesSelected,
-          buyerPrice,
-          netPrice,
-          marketHashName: targetExterior.marketHashName,
-        };
-      }).filter((entry): entry is NonNullable<typeof entry> => entry != null);
-
-      let widthSum = 0;
-      for (const entry of potential) {
-        widthSum += entry.width;
-      }
-
-      const denominator = rangeWidth > 0 ? widthSum || rangeWidth : 1;
-      const exteriors: FloatlessOutcomeExterior[] = [];
-      let robustNet: number | null = null;
-      let expectedContribution: number | null = null;
-      let expectedProbabilityCovered = 0;
-      let selectedProbability: number | null = null;
-      let dominantExterior: { exterior: Exterior; probability: number } | null = null;
-
-      for (const entry of potential) {
-        let probability: number | null = null;
-        if (rangeWidth === 0) {
-          probability = entry.containsPoint ? 1 : 0;
-        } else if (denominator > 0) {
-          probability = entry.width / denominator;
-        }
-
-        exteriors.push({
-          exterior: entry.exterior,
-          probability,
-          buyerPrice: entry.buyerPrice,
-          netPrice: entry.netPrice,
-          marketHashName: entry.marketHashName,
-        });
-
-        if (probability != null && entry.netPrice != null) {
-          if (robustNet == null || entry.netPrice < robustNet) {
-            robustNet = entry.netPrice;
-          }
-          expectedContribution = (expectedContribution ?? 0) + entry.netPrice * probability;
-          expectedProbabilityCovered += probability;
-        }
-
-        if (probability != null) {
-          if (
-            dominantExterior == null ||
-            probability > dominantExterior.probability ||
-            (probability === dominantExterior.probability && entry.exterior === selectedTarget?.exterior)
-          ) {
-            dominantExterior = { exterior: entry.exterior, probability };
-          }
-
-          if (
-            entry.matchesSelected &&
-            target.baseName === selectedTarget?.baseName &&
-            (selectedProbability == null || probability > selectedProbability)
-          ) {
-            selectedProbability = probability;
-          }
-        }
-      }
-
-      if (robustNet == null) {
-        hasRobustGap = true;
-      }
-
-      if (expectedContribution != null && expectedProbabilityCovered > 0) {
-        hasExpectedData = true;
-        expectedOutcomeNet = (expectedOutcomeNet ?? 0) + expectedContribution * baseProbability;
-        expectedCoverage += expectedProbabilityCovered * baseProbability;
-      }
-
-      if (robustNet != null) {
-        robustOutcomeNet = (robustOutcomeNet ?? 0) + robustNet * baseProbability;
-      }
-
-      outcomes.push({
-        baseName: target.baseName,
-        probability: baseProbability,
-        projectedRange: { min: normalizedMin, max: normalizedMax },
-        exteriors,
-        robustNet,
-        expectedNetContribution: expectedContribution,
-        expectedProbabilityCovered,
-      });
-
-      if (selectedTarget && target.baseName === selectedTarget.baseName) {
-        selectedTargetCoverage = {
-          probability: selectedProbability,
-          projectedRange: { min: normalizedMin, max: normalizedMax },
-          dominantExterior: dominantExterior?.exterior ?? null,
-        };
-      }
-    }
-
-    if (hasRobustGap) {
-      robustOutcomeNet = null;
-    }
-
-    if (!hasExpectedData) {
-      expectedOutcomeNet = null;
-      expectedCoverage = 0;
-    }
-
-    const robustEV = robustOutcomeNet == null ? null : robustOutcomeNet - totalNetCost;
-    const expectedEV = expectedOutcomeNet == null ? null : expectedOutcomeNet - totalNetCost;
-
-    if (
-      selectedTarget &&
-      selectedTargetCoverage &&
-      (selectedTargetCoverage.probability == null || selectedTargetCoverage.probability <= 0)
-    ) {
-      const fallbackExteriorLabel = selectedTargetCoverage.dominantExterior
-        ? `${selectedTargetCoverage.dominantExterior}`
-        : "другой экстерьер";
-      issues.push(
-        `Выбранный экстерьер ${selectedTarget.exterior} (${selectedTarget.baseName}) ` +
-          `не попадает в прогнозируемый диапазон (${selectedTargetCoverage.projectedRange.min.toFixed(5)}–${selectedTargetCoverage.projectedRange.max.toFixed(5)}). ` +
-          `Ожидаемый результат: ${fallbackExteriorLabel}.`,
-      );
-    }
-
-    return {
-      ready: issues.length === 0,
-      issues,
-      inputRange,
-      wearCounts,
-      outcomes,
-      robustOutcomeNet,
-      expectedOutcomeNet,
-      robustEV,
-      expectedEV,
-      expectedCoverage,
-    };
   }, [
     activeTargets,
     buyerToNetRate,
     catalogMap,
     rowResolution,
+    selectedTarget,
     targetPriceOverrides,
     totalNetCost,
-    selectedTarget,
   ]);
 
-  /**
-   * Отправляет форму на сервер. Перед вызовом проверяем, что заполнено 10 корректных входов.
-   */
   const calculate = React.useCallback(async () => {
     if (parsedRows.length === 0) {
       setCalculationError("Нужно добавить хотя бы один вход");

--- a/client/src/modules/tradeups/utils/format.ts
+++ b/client/src/modules/tradeups/utils/format.ts
@@ -1,0 +1,5 @@
+export const formatNumber = (value: number, digits = 2) =>
+  Number.isFinite(value) ? value.toFixed(digits) : "—";
+
+export const formatPercent = (value: number) =>
+  Number.isFinite(value) ? `${(value * 100).toFixed(2)}%` : "—";

--- a/client/src/modules/tradeups/utils/wear.ts
+++ b/client/src/modules/tradeups/utils/wear.ts
@@ -1,0 +1,17 @@
+const EXTERIOR_SHORT: Record<string, string> = {
+  "Factory New": "FN",
+  "Minimal Wear": "MW",
+  "Field-Tested": "FT",
+  "Well-Worn": "WW",
+  "Battle-Scarred": "BS",
+};
+
+export const WEAR_ORDER = [
+  "Factory New",
+  "Minimal Wear",
+  "Field-Tested",
+  "Well-Worn",
+  "Battle-Scarred",
+] as const;
+
+export const shortExterior = (exterior: string) => EXTERIOR_SHORT[exterior] ?? exterior;


### PR DESCRIPTION
## Summary
- factor tradeup builder helpers and types into dedicated modules for reuse
- have the main hook import the new helpers for row planning, resolution, and floatless analysis while re-exporting its public types

## Testing
- npm run lint
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d473a7d4308332bd72928b24a3cf21