### PR TITLE
Add single-Covert collection filter to trade-up selector

### DIFF
--- a/client/src/modules/tradeups/TradeupBuilder.tsx
+++ b/client/src/modules/tradeups/TradeupBuilder.tsx
@@ -37,6 +37,7 @@ export default function TradeupBuilder() {
     totalBuyerCost,
     totalNetCost,
     selectedCollectionDetails,
+    singleCovertCollectionTags,
     autofillPrices,
     priceLoading,
     calculate,
@@ -75,6 +76,7 @@ export default function TradeupBuilder() {
         activeCollectionTag={activeCollectionTag}
         selectCollection={selectCollection}
         selectedCollectionDetails={selectedCollectionDetails}
+        singleCovertCollectionTags={singleCovertCollectionTags}
       />
 
       <hr className="border-secondary" />

--- a/client/src/modules/tradeups/components/CollectionSelectorSection.tsx
+++ b/client/src/modules/tradeups/components/CollectionSelectorSection.tsx
@@ -9,6 +9,7 @@ interface CollectionSelectorSectionProps {
   activeCollectionTag: string | null;
   selectCollection: (tag: string) => void;
   selectedCollectionDetails: TradeupCollection[];
+  singleCovertCollectionTags: Set<string>;
 }
 
 export default function CollectionSelectorSection({
@@ -19,7 +20,20 @@ export default function CollectionSelectorSection({
   activeCollectionTag,
   selectCollection,
   selectedCollectionDetails,
+  singleCovertCollectionTags,
 }: CollectionSelectorSectionProps) {
+  const [singleCovertOnly, setSingleCovertOnly] = React.useState(false);
+
+  const collectionsToShow = React.useMemo(() => {
+    if (!singleCovertOnly) return steamCollections;
+    return steamCollections.filter((collection) =>
+      singleCovertCollectionTags.has(collection.tag),
+    );
+  }, [singleCovertOnly, steamCollections, singleCovertCollectionTags]);
+
+  const canFilterSingleCovert = singleCovertCollectionTags.size > 0;
+  const showEmptyState = singleCovertOnly && collectionsToShow.length === 0;
+
   return (
     <section>
       <h3 className="h5">1. Выбор коллекции</h3>
@@ -32,14 +46,27 @@ export default function CollectionSelectorSection({
         >
           {loadingSteamCollections ? "Загрузка…" : "Get all collections"}
         </button>
+        <div className="form-check form-switch text-nowrap small mb-0">
+          <input
+            className="form-check-input"
+            type="checkbox"
+            id="singleCovertOnly"
+            checked={singleCovertOnly && canFilterSingleCovert}
+            onChange={(event) => setSingleCovertOnly(event.target.checked)}
+            disabled={!canFilterSingleCovert}
+          />
+          <label className="form-check-label" htmlFor="singleCovertOnly">
+            Только 1 Covert
+          </label>
+        </div>
         {steamCollections.length === 0 && !loadingSteamCollections && (
           <span className="text-muted small">Нажмите кнопку, чтобы получить список коллекций.</span>
         )}
       </div>
       {steamCollectionError && <div className="text-danger mb-2">{steamCollectionError}</div>}
-      {steamCollections.length > 0 && (
+      {collectionsToShow.length > 0 && (
         <div className="tradeup-collections-list">
-          {steamCollections.map((collection) => {
+          {collectionsToShow.map((collection) => {
             const isActive = collection.tag === activeCollectionTag;
             const supported = Boolean(collection.collectionId);
             return (
@@ -55,6 +82,9 @@ export default function CollectionSelectorSection({
             );
           })}
         </div>
+      )}
+      {showEmptyState && (
+        <div className="text-muted small">Нет коллекций с одним Covert скином.</div>
       )}
       {selectedCollectionDetails.length > 0 && (
         <div className="mt-3">

--- a/client/src/modules/tradeups/hooks/types.ts
+++ b/client/src/modules/tradeups/hooks/types.ts
@@ -132,6 +132,7 @@ export interface TradeupBuilderState {
   totalBuyerCost: number;
   totalNetCost: number;
   selectedCollectionDetails: TradeupCollection[];
+  singleCovertCollectionTags: Set<string>;
   autofillPrices: (namesOverride?: string[]) => Promise<void> | void;
   priceLoading: boolean;
   calculate: () => Promise<void>;

--- a/client/src/modules/tradeups/hooks/useTradeupBuilder.ts
+++ b/client/src/modules/tradeups/hooks/useTradeupBuilder.ts
@@ -99,6 +99,24 @@ export default function useTradeupBuilder() {
     return new Map(catalogCollections.map((collection) => [collection.id, collection] as const));
   }, [catalogCollections]);
 
+  const singleCovertCollectionIds = React.useMemo(() => {
+    return new Set(
+      catalogCollections
+        .filter((collection) => collection.covert.length === 1)
+        .map((collection) => collection.id),
+    );
+  }, [catalogCollections]);
+
+  const singleCovertCollectionTags = React.useMemo(() => {
+    const tags = new Set<string>();
+    for (const entry of steamCollections) {
+      if (entry.collectionId && singleCovertCollectionIds.has(entry.collectionId)) {
+        tags.add(entry.tag);
+      }
+    }
+    return tags;
+  }, [steamCollections, singleCovertCollectionIds]);
+
   /** Отдельная карта steam-tag → информация о коллекции для быстрых lookup'ов. */
   const steamCollectionsByTag = React.useMemo(
     () => new Map(steamCollections.map((entry) => [entry.tag, entry] as const)),
@@ -744,6 +762,7 @@ export default function useTradeupBuilder() {
     totalBuyerCost,
     totalNetCost,
     selectedCollectionDetails,
+    singleCovertCollectionTags,
     autofillPrices,
     priceLoading,
     calculate,


### PR DESCRIPTION
## Summary
- compute the set of collections that contain only one Covert skin in the trade-up builder state
- expose the set to the UI and add a toggle to show only single-Covert collections in the selector
- show an empty-state hint when no collections match the filter

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68db29ca90608332830271c0ea2182ea