### PR TITLE
Add toggle to choose trade-up target rarity

### DIFF
--- a/client/src/modules/tradeups/TradeupBuilder.tsx
+++ b/client/src/modules/tradeups/TradeupBuilder.tsx
@@ -20,6 +20,8 @@ export default function TradeupBuilder() {
     loadingSteamCollections,
     steamCollectionError,
     activeCollectionTag,
+    targetRarity,
+    setTargetRarity,
     selectCollection,
     collectionTargets,
     loadingTargets,
@@ -81,6 +83,8 @@ export default function TradeupBuilder() {
 
       <TargetSelectionSection
         activeCollectionTag={activeCollectionTag}
+        targetRarity={targetRarity}
+        setTargetRarity={setTargetRarity}
         collectionTargets={collectionTargets}
         loadingTargets={loadingTargets}
         targetsError={targetsError}

--- a/client/src/modules/tradeups/components/TargetSelectionSection.tsx
+++ b/client/src/modules/tradeups/components/TargetSelectionSection.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type {
   CollectionTargetExterior,
   CollectionTargetSummary,
+  TargetRarity,
 } from "../services/api";
 import type { SelectedTarget } from "../hooks/useTradeupBuilder";
 import { formatNumber } from "../utils/format";
@@ -9,6 +10,8 @@ import { shortExterior } from "../utils/wear";
 
 interface TargetSelectionSectionProps {
   activeCollectionTag: string | null;
+  targetRarity: TargetRarity;
+  setTargetRarity: (rarity: TargetRarity) => void;
   collectionTargets: CollectionTargetSummary[];
   loadingTargets: boolean;
   targetsError: string | null;
@@ -24,6 +27,8 @@ interface TargetSelectionSectionProps {
 
 export default function TargetSelectionSection({
   activeCollectionTag,
+  targetRarity,
+  setTargetRarity,
   collectionTargets,
   loadingTargets,
   targetsError,
@@ -32,14 +37,37 @@ export default function TargetSelectionSection({
   inputsLoading,
   inputsError,
 }: TargetSelectionSectionProps) {
+  const rarityLabel = targetRarity === "Covert" ? "Covert" : "Classified";
+
   return (
     <section>
       <h3 className="h5">2. Целевой скин</h3>
+      <div className="d-flex flex-wrap align-items-center gap-2 mb-2">
+        <span className="text-muted small">Качество результата:</span>
+        <div className="btn-group btn-group-sm" role="group">
+          <button
+            type="button"
+            className={`btn ${targetRarity === "Covert" ? "btn-primary" : "btn-outline-light"}`}
+            onClick={() => setTargetRarity("Covert")}
+            disabled={loadingTargets}
+          >
+            Covert
+          </button>
+          <button
+            type="button"
+            className={`btn ${targetRarity === "Classified" ? "btn-primary" : "btn-outline-light"}`}
+            onClick={() => setTargetRarity("Classified")}
+            disabled={loadingTargets}
+          >
+            Classified
+          </button>
+        </div>
+      </div>
       {!activeCollectionTag && <div className="text-muted">Сначала выберите коллекцию.</div>}
       {targetsError && <div className="text-danger">{targetsError}</div>}
       {loadingTargets && <div className="text-muted">Загрузка скинов…</div>}
       {activeCollectionTag && !loadingTargets && collectionTargets.length === 0 && !targetsError && (
-        <div className="text-muted">Для этой коллекции не найдены Covert-скины.</div>
+        <div className="text-muted">Для этой коллекции не найдены {rarityLabel}-скины.</div>
       )}
       {collectionTargets.length > 0 && (
         <div className="tradeup-targets">

--- a/client/src/modules/tradeups/hooks/types.ts
+++ b/client/src/modules/tradeups/hooks/types.ts
@@ -2,6 +2,7 @@ import type { Exterior } from "../../skins/services/types";
 import type {
   CollectionInputSummary,
   CollectionTargetsResponse,
+  TargetRarity,
   TradeupCalculationResponse,
   TradeupCollection,
 } from "../services/api";
@@ -96,7 +97,7 @@ export interface CollectionLookupContext {
   catalogMap: Map<string, TradeupCollection>;
   steamCollections: Array<{ tag: string; name: string; collectionId: string | null }>;
   steamCollectionsByTag: Map<string, { tag: string; name: string; collectionId: string | null }>;
-  targetsByCollection: Record<string, CollectionTargetsResponse>;
+  targetsByCollection: Record<string, Partial<Record<TargetRarity, CollectionTargetsResponse>>>;
   inputsByCollection: Record<
     string,
     { collectionId: string | null; collectionTag: string; inputs: CollectionInputSummary[] }
@@ -111,6 +112,8 @@ export interface TradeupBuilderState {
   loadingSteamCollections: boolean;
   steamCollectionError: string | null;
   activeCollectionTag: string | null;
+  targetRarity: TargetRarity;
+  setTargetRarity: (rarity: TargetRarity) => void;
   selectCollection: (tag: string) => void;
   collectionTargets: CollectionTargetsResponse["targets"];
   loadingTargets: boolean;

--- a/client/src/modules/tradeups/services/api.ts
+++ b/client/src/modules/tradeups/services/api.ts
@@ -1,6 +1,8 @@
 import type { Exterior } from "../../skins/services/types";
 import { batchPriceOverview } from "../../skins/services/api";
 
+export type TargetRarity = "Covert" | "Classified";
+
 /**
  * Клиентский слой работы с trade-up API. Предоставляет функции для загрузки коллекций,
  * целей, входов и для отправки данных на расчёт EV.
@@ -41,6 +43,7 @@ export interface CollectionTargetSummary {
 export interface CollectionTargetsResponse {
   collectionTag: string;
   collectionId: string | null;
+  rarity: TargetRarity;
   targets: CollectionTargetSummary[];
 }
 
@@ -145,9 +148,12 @@ export async function fetchSteamCollections() {
   return payload.collections;
 }
 
-/** Получает список Covert-результатов для конкретного Steam tag'а. */
-export async function fetchCollectionTargets(collectionTag: string) {
-  const response = await fetch(`/api/tradeups/collections/${encodeURIComponent(collectionTag)}/targets`);
+/** Получает список результатов указанной редкости для конкретного Steam tag'а. */
+export async function fetchCollectionTargets(collectionTag: string, rarity: TargetRarity = "Covert") {
+  const qs = new URLSearchParams({ rarity });
+  const response = await fetch(
+    `/api/tradeups/collections/${encodeURIComponent(collectionTag)}/targets?${qs.toString()}`,
+  );
   if (!response.ok) {
     throw new Error(`HTTP ${response.status}`);
   }

--- a/server/src/modules/tradeups/router.ts
+++ b/server/src/modules/tradeups/router.ts
@@ -99,7 +99,10 @@ export const createTradeupsRouter = () => {
       return response.status(400).json({ error: "collectionTag is required" });
     }
     try {
-      const result = await fetchCollectionTargets(collectionTag);
+      const rarityParam = String(request.query?.rarity ?? "Covert").trim();
+      const normalized = rarityParam.toLowerCase();
+      const rarity = normalized === "classified" ? "Classified" : "Covert";
+      const result = await fetchCollectionTargets(collectionTag, rarity);
       response.json(result);
     } catch (error) {
       response.status(503).json({ error: String(error) });

--- a/server/src/modules/tradeups/service.ts
+++ b/server/src/modules/tradeups/service.ts
@@ -357,6 +357,7 @@ export interface CollectionTargetSummary {
 export interface CollectionTargetsResult {
   collectionTag: string;
   collectionId: string | null;
+  rarity: "Covert" | "Classified";
   targets: CollectionTargetSummary[];
 }
 
@@ -365,16 +366,17 @@ export interface CollectionTargetsResult {
  */
 export const fetchCollectionTargets = async (
   collectionTag: string,
+  rarity: "Covert" | "Classified" = "Covert",
 ): Promise<CollectionTargetsResult> => {
   ensureCollectionCaches();
-  const items = await fetchEntireCollection({ collectionTag, rarity: "Covert" });
+  const items = await fetchEntireCollection({ collectionTag, rarity });
   const grouped = new Map<string, CollectionTargetSummary>();
   const baseNames: string[] = [];
 
   for (const item of items) {
     const exterior = parseMarketHashExterior(item.market_hash_name);
     const baseName = baseFromMarketHash(item.market_hash_name);
-    const floats = COVERT_FLOAT_BY_BASENAME.get(baseName);
+    const floats = rarity === "Covert" ? COVERT_FLOAT_BY_BASENAME.get(baseName) : undefined;
 
     let entry = grouped.get(baseName);
     if (!entry) {
@@ -403,6 +405,7 @@ export const fetchCollectionTargets = async (
   return {
     collectionTag,
     collectionId,
+    rarity,
     targets: Array.from(grouped.values()),
   };
 };


### PR DESCRIPTION
## Summary
- add API support for requesting trade-up targets by rarity instead of assuming Covert
- add a rarity toggle in the trade-up builder UI to switch between Covert and Classified targets
- update client caching and selection logic to handle per-rarity target data and reuse collection IDs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc45d5a1f483328b06657c9ca0fb0b