### PR TITLE
Add real purchase verification to trade-up results

### DIFF
--- a/client/src/modules/tradeups/TradeupBuilder.tsx
+++ b/client/src/modules/tradeups/TradeupBuilder.tsx
@@ -46,6 +46,10 @@ export default function TradeupBuilder() {
     calculating,
     calculationError,
     floatlessAnalysis,
+    realPurchaseCheckResult,
+    realPurchaseCheckError,
+    realPurchaseCheckLoading,
+    runRealPurchaseCheck,
   } = useTradeupBuilder();
 
   return (
@@ -110,7 +114,16 @@ export default function TradeupBuilder() {
 
       <FloatlessAnalysisSection floatlessAnalysis={floatlessAnalysis} />
 
-      {calculation && <ResultsSection calculation={calculation} totalBuyerCost={totalBuyerCost} />}
+      {calculation && (
+        <ResultsSection
+          calculation={calculation}
+          totalBuyerCost={totalBuyerCost}
+          onRunRealPurchaseCheck={runRealPurchaseCheck}
+          realPurchaseCheckResult={realPurchaseCheckResult}
+          realPurchaseCheckLoading={realPurchaseCheckLoading}
+          realPurchaseCheckError={realPurchaseCheckError}
+        />
+      )}
     </div>
   );
 }

--- a/client/src/modules/tradeups/components/ResultsSection.tsx
+++ b/client/src/modules/tradeups/components/ResultsSection.tsx
@@ -1,13 +1,30 @@
 import React from "react";
+import type { RealPurchaseCheckResult } from "../hooks/useTradeupBuilder";
 import type { TradeupCalculationResponse } from "../services/api";
 import { formatNumber, formatPercent } from "../utils/format";
 
 interface ResultsSectionProps {
   calculation: TradeupCalculationResponse;
   totalBuyerCost: number;
+  onRunRealPurchaseCheck: () => void;
+  realPurchaseCheckResult: RealPurchaseCheckResult | null;
+  realPurchaseCheckLoading: boolean;
+  realPurchaseCheckError: string | null;
 }
 
-export default function ResultsSection({ calculation, totalBuyerCost }: ResultsSectionProps) {
+export default function ResultsSection({
+  calculation,
+  totalBuyerCost,
+  onRunRealPurchaseCheck,
+  realPurchaseCheckResult,
+  realPurchaseCheckLoading,
+  realPurchaseCheckError,
+}: ResultsSectionProps) {
+  const topRealPurchaseItems = React.useMemo(() => {
+    if (!realPurchaseCheckResult?.items?.length) return [];
+    return realPurchaseCheckResult.items.slice(0, 10);
+  }, [realPurchaseCheckResult]);
+
   return (
     <section className="mt-4">
       <h3 className="h5">4. Результаты</h3>
@@ -34,6 +51,72 @@ export default function ResultsSection({ calculation, totalBuyerCost }: ResultsS
             ))}
           </ul>
         </div>
+      )}
+
+      <div className="d-flex flex-wrap align-items-center gap-2 mt-3">
+        <button
+          type="button"
+          className="btn btn-outline-light btn-sm"
+          onClick={() => onRunRealPurchaseCheck()}
+          disabled={realPurchaseCheckLoading}
+        >
+          {realPurchaseCheckLoading ? "Проверка…" : "Проверка реальности покупки"}
+        </button>
+        {realPurchaseCheckLoading && <span className="small text-muted">Подбор входов…</span>}
+      </div>
+      {realPurchaseCheckError && <div className="text-danger mt-2">{realPurchaseCheckError}</div>}
+
+      {realPurchaseCheckResult && topRealPurchaseItems.length > 0 && (
+        <div className="card bg-secondary-subtle text-dark mt-3">
+          <div className="card-body p-3">
+            <div className="d-flex flex-wrap justify-content-between align-items-start gap-2">
+              <div>
+                <div className="fw-semibold">
+                  Лучшие входы ({realPurchaseCheckResult.rarity})
+                </div>
+                {realPurchaseCheckResult.collectionName && (
+                  <div className="small text-muted">{realPurchaseCheckResult.collectionName}</div>
+                )}
+              </div>
+              <div className="small text-muted">
+                Показаны топ {topRealPurchaseItems.length} по минимальному float
+              </div>
+            </div>
+            <div className="table-responsive mt-2">
+              <table className="table table-sm align-middle mb-0">
+                <thead>
+                  <tr>
+                    <th>#</th>
+                    <th>Предмет</th>
+                    <th>Float диапазон</th>
+                    <th>Buyer $</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {topRealPurchaseItems.map((item, index) => {
+                    const floatRange =
+                      item.minFloat != null && item.maxFloat != null
+                        ? `${item.minFloat.toFixed(5)} — ${item.maxFloat.toFixed(5)}`
+                        : item.minFloat != null
+                        ? `${item.minFloat.toFixed(5)} — ?`
+                        : "—";
+                    return (
+                      <tr key={item.marketHashName}>
+                        <td>{index + 1}</td>
+                        <td>{`${item.baseName} (${item.exterior})`}</td>
+                        <td>{floatRange}</td>
+                        <td>{item.price != null ? `$${formatNumber(item.price)}` : "—"}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      )}
+      {realPurchaseCheckResult && topRealPurchaseItems.length === 0 && !realPurchaseCheckError && (
+        <div className="text-muted mt-2">Не удалось подобрать входы с известным float.</div>
       )}
 
       <div className="table-responsive mt-3">

--- a/client/src/modules/tradeups/hooks/types.ts
+++ b/client/src/modules/tradeups/hooks/types.ts
@@ -44,6 +44,22 @@ export interface SelectedTarget {
   price?: number | null;
 }
 
+export interface RealPurchaseItem {
+  baseName: string;
+  marketHashName: string;
+  exterior: Exterior;
+  price: number | null;
+  minFloat: number | null;
+  maxFloat: number | null;
+}
+
+export interface RealPurchaseCheckResult {
+  collectionTag: string | null;
+  collectionName: string | null;
+  rarity: "Classified" | "Restricted";
+  items: RealPurchaseItem[];
+}
+
 export interface ResolvedTradeupRow {
   marketHashName: string;
   collectionId: string;
@@ -140,4 +156,8 @@ export interface TradeupBuilderState {
   calculating: boolean;
   calculationError: string | null;
   floatlessAnalysis: FloatlessAnalysisResult;
+  realPurchaseCheckResult: RealPurchaseCheckResult | null;
+  realPurchaseCheckError: string | null;
+  realPurchaseCheckLoading: boolean;
+  runRealPurchaseCheck: () => Promise<void>;
 }

--- a/client/src/modules/tradeups/services/api.ts
+++ b/client/src/modules/tradeups/services/api.ts
@@ -57,6 +57,8 @@ export interface CollectionInputSummary {
   marketHashName: string;
   exterior: Exterior;
   price?: number | null;
+  minFloat?: number;
+  maxFloat?: number;
 }
 
 export interface CollectionInputsResponse {


### PR DESCRIPTION
## Summary
- add a "Проверка реальности покупки" action to the results view and show the lowest-float inputs with prices
- extend the trade-up builder hook and types to fetch candidate inputs and reuse cached pricing
- expose float metadata for collection inputs on the API and adjust the server import to support default exports

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68dd69ae07208332aceea7e9219cb584