### PR TITLE
Add trade-up availability check flow

### DIFF
--- a/client/src/modules/tradeups/TradeupBuilder.tsx
+++ b/client/src/modules/tradeups/TradeupBuilder.tsx
@@ -46,6 +46,8 @@ export default function TradeupBuilder() {
     calculating,
     calculationError,
     floatlessAnalysis,
+    availabilityState,
+    checkAvailability,
   } = useTradeupBuilder();
 
   return (
@@ -110,7 +112,14 @@ export default function TradeupBuilder() {
 
       <FloatlessAnalysisSection floatlessAnalysis={floatlessAnalysis} />
 
-      {calculation && <ResultsSection calculation={calculation} totalBuyerCost={totalBuyerCost} />}
+      {calculation && (
+        <ResultsSection
+          calculation={calculation}
+          totalBuyerCost={totalBuyerCost}
+          availabilityState={availabilityState}
+          onCheckAvailability={checkAvailability}
+        />
+      )}
     </div>
   );
 }

--- a/client/src/modules/tradeups/components/AvailabilitySuggestionSection.tsx
+++ b/client/src/modules/tradeups/components/AvailabilitySuggestionSection.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import type { TradeupCalculationResponse } from "../services/api";
+import type { TradeupAvailabilityState } from "../hooks/types";
+import { formatNumber } from "../utils/format";
+
+interface AvailabilitySuggestionSectionProps {
+  availabilityState: TradeupAvailabilityState;
+  inputs: TradeupCalculationResponse["inputs"];
+}
+
+const formatFloat = (value: number | null | undefined, fallback = "—") => {
+  if (value == null || Number.isNaN(value)) {
+    return fallback;
+  }
+  return value.toFixed(5);
+};
+
+export default function AvailabilitySuggestionSection({
+  availabilityState,
+  inputs,
+}: AvailabilitySuggestionSectionProps) {
+  const { outcomeLabel, loading, error, result } = availabilityState;
+
+  if (!outcomeLabel && !loading && !error && !result) {
+    return null;
+  }
+
+  const differenceText =
+    result?.targetAverageFloat != null && result?.assignedAverageFloat != null
+      ? (result.assignedAverageFloat - result.targetAverageFloat).toFixed(5)
+      : null;
+
+  return (
+    <section className="mt-4">
+      <h4 className="h6 mb-2">
+        Подбор входов{outcomeLabel ? ` • ${outcomeLabel}` : ""}
+      </h4>
+      {loading && <div className="text-info small mb-2">Поиск доступных предметов…</div>}
+      {error && <div className="text-danger small mb-2">{error}</div>}
+      {result && (
+        <>
+          <div className="text-muted small mb-2">
+            Целевой средний float: {formatFloat(result.targetAverageFloat)}
+            {result.assignedAverageFloat != null && (
+              <>
+                {" "}• Подобранный: {formatFloat(result.assignedAverageFloat)}
+                {differenceText != null && <>{" "}(Δ {differenceText})</>}
+              </>
+            )}
+          </div>
+          <div className="table-responsive">
+            <table className="table table-dark table-sm align-middle tradeup-table">
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>Запланированный market_hash_name</th>
+                  <th>Подобранный listing</th>
+                  <th>Float</th>
+                  <th>Buyer $</th>
+                  <th>Inspect</th>
+                </tr>
+              </thead>
+              <tbody>
+                {inputs.map((input, index) => {
+                  const slot = result.slots.find((entry) => entry.index === index);
+                  const listing = slot?.listing ?? null;
+                  const priceText =
+                    listing?.price != null ? `$${formatNumber(listing.price)}` : "—";
+                  let floatText = "—";
+                  if (listing?.float != null) {
+                    floatText = formatFloat(listing.float);
+                  } else if (listing?.floatError) {
+                    floatText = `Ошибка: ${listing.floatError}`;
+                  }
+                  return (
+                    <tr key={index}>
+                      <td>{index + 1}</td>
+                      <td>{input.marketHashName}</td>
+                      <td>{listing?.marketHashName ?? "—"}</td>
+                      <td>{floatText}</td>
+                      <td>{priceText}</td>
+                      <td>
+                        {listing?.inspectLink ? (
+                          <a
+                            href={listing.inspectLink}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="link-info"
+                          >
+                            Inspect
+                          </a>
+                        ) : (
+                          "—"
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+          {result.missingSlots.length > 0 && (
+            <div className="text-warning small mt-2">
+              Не удалось подобрать предметы для слотов:{" "}
+              {result.missingSlots.map((idx) => idx + 1).join(", ")}
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/client/src/modules/tradeups/hooks/types.ts
+++ b/client/src/modules/tradeups/hooks/types.ts
@@ -4,6 +4,7 @@ import type {
   CollectionInputsResponse,
   CollectionTargetsResponse,
   TargetRarity,
+  TradeupAvailabilityResponse,
   TradeupCalculationResponse,
   TradeupCollection,
 } from "../services/api";
@@ -140,4 +141,17 @@ export interface TradeupBuilderState {
   calculating: boolean;
   calculationError: string | null;
   floatlessAnalysis: FloatlessAnalysisResult;
+  availabilityState: TradeupAvailabilityState;
+  checkAvailability: (
+    outcome: TradeupCalculationResponse["outcomes"][number],
+  ) => Promise<void>;
+}
+
+export interface TradeupAvailabilityState {
+  activeOutcomeKey: string | null;
+  loading: boolean;
+  error: string | null;
+  result: TradeupAvailabilityResponse | null;
+  outcomeLabel: string | null;
+  outcomeMarketHashName: string | null;
 }

--- a/client/src/modules/tradeups/services/api.ts
+++ b/client/src/modules/tradeups/services/api.ts
@@ -135,6 +135,56 @@ export interface TradeupCalculationResponse {
   warnings: string[];
 }
 
+export interface TradeupAvailabilityOutcomePayload {
+  marketHashName: string;
+  minFloat?: number | null;
+  maxFloat?: number | null;
+  rollFloat?: number | null;
+}
+
+export interface TradeupAvailabilitySlotPayload {
+  index: number;
+  marketHashName: string;
+}
+
+export interface TradeupAvailabilityRequestPayload {
+  outcome: TradeupAvailabilityOutcomePayload;
+  slots: TradeupAvailabilitySlotPayload[];
+  limit?: number;
+  targetAverageFloat?: number | null;
+}
+
+export interface TradeupAvailabilityListing {
+  listingId: string | null;
+  assetId: string | null;
+  marketHashName: string;
+  price: number | null;
+  float: number | null;
+  floatError?: string | null;
+  inspectLink: string | null;
+  sellerId: string | null;
+}
+
+export interface TradeupAvailabilitySlotResult {
+  index: number;
+  marketHashName: string;
+  listing: TradeupAvailabilityListing | null;
+}
+
+export interface TradeupAvailabilityResponse {
+  outcome: {
+    marketHashName: string;
+    minFloat: number | null;
+    maxFloat: number | null;
+    rollFloat: number | null;
+  };
+  targetAverageFloat: number | null;
+  assignedAverageFloat: number | null;
+  slots: TradeupAvailabilitySlotResult[];
+  missingSlots: number[];
+  groups: Record<string, TradeupAvailabilityListing[]>;
+}
+
 /** Загружает локальный справочник коллекций с float-диапазонами. */
 export async function fetchTradeupCollections() {
   const response = await fetch("/api/tradeups/collections");
@@ -194,6 +244,19 @@ export async function requestTradeupCalculation(payload: TradeupCalculationPaylo
     throw new Error(text || `HTTP ${response.status}`);
   }
   return (await response.json()) as TradeupCalculationResponse;
+}
+
+export async function requestTradeupAvailability(payload: TradeupAvailabilityRequestPayload) {
+  const response = await fetch("/api/tradeups/availability", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || `HTTP ${response.status}`);
+  }
+  return (await response.json()) as TradeupAvailabilityResponse;
 }
 
 export { batchPriceOverview };


### PR DESCRIPTION
## Summary
- add a “check availability” action to the trade-up results table and show suggested inputs in a new helper table
- extend the client trade-up hook and API layer to request availability data for current inputs
- implement a server endpoint that gathers Steam listings, throttles float lookups, and assembles the best-fit inputs for a target outcome

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e1b005cfe48332958bb70f63a624ac