### PR TITLE
feat: add collection analyzer tab

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import SkinsBrowser from "./modules/skins";
 import TradeupBuilder from "./modules/tradeups";
+import CollectionAnalyzer from "./modules/collections";
 import {
   fetchCollectionsSyncStatus,
   requestCollectionsSync,
@@ -8,7 +9,9 @@ import {
 } from "./modules/tradeups/services/api";
 
 const App: React.FC = () => {
-  const [activeTab, setActiveTab] = React.useState<"browser" | "tradeup">("browser");
+  const [activeTab, setActiveTab] = React.useState<"browser" | "tradeup" | "collections">(
+    "browser",
+  );
   const [syncOverview, setSyncOverview] = React.useState<{
     active: SyncJobStatus | null;
     jobs: SyncJobStatus[];
@@ -128,26 +131,29 @@ const App: React.FC = () => {
         </div>
       </div>
       <ul className="nav nav-tabs mb-3">
-        <li className="nav-item">
-          <button
-            className={`nav-link ${activeTab === "tradeup" ? "" : "active"}`}
-            type="button"
-            onClick={() => setActiveTab("browser")}
-          >
-            Market Browser
-          </button>
-        </li>
-        <li className="nav-item">
-          <button
-            className={`nav-link ${activeTab === "tradeup" ? "active" : ""}`}
-            type="button"
-            onClick={() => setActiveTab("tradeup")}
-          >
-            Trade-Up Calculator
-          </button>
-        </li>
+        {[
+          { id: "browser" as const, label: "Market Browser" },
+          { id: "tradeup" as const, label: "Trade-Up Calculator" },
+          { id: "collections" as const, label: "Анализ коллекций" },
+        ].map((tab) => (
+          <li key={tab.id} className="nav-item">
+            <button
+              className={`nav-link ${activeTab === tab.id ? "active" : ""}`}
+              type="button"
+              onClick={() => setActiveTab(tab.id)}
+            >
+              {tab.label}
+            </button>
+          </li>
+        ))}
       </ul>
-      {activeTab === "tradeup" ? <TradeupBuilder /> : <SkinsBrowser />}
+      {activeTab === "tradeup" ? (
+        <TradeupBuilder />
+      ) : activeTab === "collections" ? (
+        <CollectionAnalyzer />
+      ) : (
+        <SkinsBrowser />
+      )}
     </div>
   );
 };

--- a/client/src/modules/collections/CollectionAnalyzer.css
+++ b/client/src/modules/collections/CollectionAnalyzer.css
@@ -124,6 +124,11 @@
   color: rgba(255, 255, 255, 0.6);
 }
 
+.collection-chart__profit {
+  font-size: 0.85rem;
+  margin-top: 0.15rem;
+}
+
 .collection-analyzer__empty {
   color: rgba(255, 255, 255, 0.65);
 }

--- a/client/src/modules/collections/CollectionAnalyzer.css
+++ b/client/src/modules/collections/CollectionAnalyzer.css
@@ -98,6 +98,27 @@
   color: rgba(255, 255, 255, 0.65);
 }
 
+.collection-chart__targets {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.collection-chart__targets-list {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.collection-chart__target {
+  display: inline-flex;
+  gap: 0.3rem;
+  align-items: baseline;
+}
+
+.collection-chart__target--primary {
+  font-weight: 600;
+}
+
 .collection-chart__inputs {
   font-size: 0.8rem;
   color: rgba(255, 255, 255, 0.6);

--- a/client/src/modules/collections/CollectionAnalyzer.css
+++ b/client/src/modules/collections/CollectionAnalyzer.css
@@ -1,0 +1,113 @@
+.collection-analyzer {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.collection-analyzer__layout {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: minmax(220px, 280px) 1fr;
+}
+
+@media (max-width: 992px) {
+  .collection-analyzer__layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.collection-analyzer__collections {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.collection-analyzer__collections-search {
+  position: relative;
+}
+
+.collection-analyzer__collections-search input {
+  width: 100%;
+}
+
+.collection-analyzer__collections-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 480px;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.collection-analyzer__collections-list .btn {
+  justify-content: flex-start;
+  text-align: left;
+  white-space: normal;
+}
+
+.collection-analyzer__results {
+  display: grid;
+  gap: 1rem;
+}
+
+.collection-analyzer__summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: baseline;
+}
+
+.collection-chart {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.collection-chart__row {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.collection-chart__label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+}
+
+.collection-chart__bar {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  position: relative;
+  overflow: hidden;
+  height: 32px;
+  display: flex;
+  align-items: center;
+}
+
+.collection-chart__bar-fill {
+  background: linear-gradient(90deg, rgba(0, 123, 255, 0.7), rgba(0, 200, 255, 0.9));
+  height: 100%;
+}
+
+.collection-chart__value {
+  position: absolute;
+  right: 12px;
+  font-weight: 600;
+}
+
+.collection-chart__meta {
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.collection-chart__inputs {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.collection-analyzer__empty {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.collection-analyzer__error {
+  color: #ffb3b3;
+}
+

--- a/client/src/modules/collections/CollectionAnalyzer.tsx
+++ b/client/src/modules/collections/CollectionAnalyzer.tsx
@@ -146,9 +146,23 @@ const analyzeCollection = async (collectionTag: string): Promise<CollectionAnaly
     }
   }
 
-  const entries = Array.from(bestByTarget.values()).sort(
-    (a, b) => b.ratioPercent - a.ratioPercent,
-  );
+  let entries = Array.from(bestByTarget.values());
+
+  if (entries.length) {
+    const raritiesPresent = new Set(entries.map((entry) => entry.targetRarity));
+    const rarityToExclude = [...TRADEUP_RARITIES]
+      .reverse()
+      .find((rarity) => raritiesPresent.has(rarity));
+
+    if (rarityToExclude) {
+      const filtered = entries.filter((entry) => entry.targetRarity !== rarityToExclude);
+      if (filtered.length) {
+        entries = filtered;
+      }
+    }
+  }
+
+  entries.sort((a, b) => b.ratioPercent - a.ratioPercent);
   return { entries, warnings };
 };
 

--- a/client/src/modules/collections/CollectionAnalyzer.tsx
+++ b/client/src/modules/collections/CollectionAnalyzer.tsx
@@ -1,0 +1,324 @@
+import React from "react";
+import {
+  fetchCollectionTargets,
+  fetchCollectionInputs,
+  type CollectionInputSummary,
+  type CollectionTargetsResponse,
+  type TargetRarity,
+} from "../tradeups/services/api";
+import { useSteamCollections } from "../tradeups/hooks/builder/useSteamCollections";
+import type { Exterior } from "../skins/services/types";
+import "./CollectionAnalyzer.css";
+
+const TRADEUP_RARITIES: TargetRarity[] = [
+  "Covert",
+  "Classified",
+  "Restricted",
+  "Mil-Spec",
+  "Industrial",
+];
+
+const TARGET_RARITY_TITLES: Record<TargetRarity, string> = {
+  Covert: "Covert",
+  Classified: "Classified",
+  Restricted: "Restricted",
+  "Mil-Spec": "Mil-Spec",
+  Industrial: "Industrial",
+  Consumer: "Consumer",
+};
+
+interface CollectionAnalysisEntry {
+  key: string;
+  targetRarity: TargetRarity;
+  inputRarity: string | null;
+  targetBaseName: string;
+  targetMarketHashName: string;
+  targetExterior: Exterior;
+  targetPrice: number;
+  inputMarketHashName: string;
+  inputPrice: number;
+  totalInputCost: number;
+  ratioPercent: number;
+}
+
+interface CollectionAnalysis {
+  entries: CollectionAnalysisEntry[];
+  warnings: string[];
+}
+
+const INPUTS_REQUIRED = 10;
+
+const formatCurrency = (value: number) =>
+  new Intl.NumberFormat("ru-RU", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  }).format(value);
+
+const buildTargetKey = (
+  rarity: TargetRarity,
+  target: CollectionTargetsResponse["targets"][number],
+  exterior: CollectionTargetsResponse["targets"][number]["exteriors"][number],
+) => `${rarity}:${target.baseName}:${exterior.marketHashName}`;
+
+const analyzeCollection = async (collectionTag: string): Promise<CollectionAnalysis> => {
+  const bestByTarget = new Map<string, CollectionAnalysisEntry>();
+  const warnings: string[] = [];
+
+  for (const targetRarity of TRADEUP_RARITIES) {
+    let targets: CollectionTargetsResponse["targets"]; // undefined until fetched
+    let inputs: CollectionInputSummary[];
+    let inputRarity: string | null = null;
+
+    try {
+      const response = await fetchCollectionTargets(collectionTag, targetRarity);
+      targets = response.targets ?? [];
+      if (!targets.length) {
+        continue;
+      }
+      inputRarity = response.rarity ?? null;
+    } catch (error: any) {
+      warnings.push(
+        `Не удалось загрузить результаты редкости ${TARGET_RARITY_TITLES[targetRarity]}: ${String(
+          error?.message || error,
+        )}`,
+      );
+      continue;
+    }
+
+    let inputsResponse;
+    try {
+      inputsResponse = await fetchCollectionInputs(collectionTag, targetRarity);
+    } catch (error: any) {
+      warnings.push(
+        `Не удалось загрузить входы для редкости ${TARGET_RARITY_TITLES[targetRarity]}: ${String(
+          error?.message || error,
+        )}`,
+      );
+      continue;
+    }
+
+    inputRarity = inputsResponse.rarity ?? inputRarity;
+    inputs = inputsResponse.inputs ?? [];
+
+    const pricedInputs = inputs.filter(
+      (input) => typeof input.price === "number" && (input.price ?? 0) > 0,
+    );
+    if (!pricedInputs.length) {
+      warnings.push(
+        `Нет цен для входов (${inputsResponse.rarity ?? "?"}) в коллекции ${collectionTag}.`,
+      );
+      continue;
+    }
+
+    for (const input of pricedInputs) {
+      const price = input.price ?? null;
+      if (price == null || price <= 0) {
+        continue;
+      }
+      const totalInputCost = price * INPUTS_REQUIRED;
+      for (const target of targets) {
+        for (const exterior of target.exteriors) {
+          const targetPrice = exterior.price ?? null;
+          if (targetPrice == null || targetPrice <= 0) {
+            continue;
+          }
+          const ratioPercent = (targetPrice / totalInputCost) * 100;
+          const key = buildTargetKey(targetRarity, target, exterior);
+          const current = bestByTarget.get(key);
+          if (!current || ratioPercent > current.ratioPercent) {
+            bestByTarget.set(key, {
+              key,
+              targetRarity,
+              inputRarity,
+              targetBaseName: target.baseName,
+              targetMarketHashName: exterior.marketHashName,
+              targetExterior: exterior.exterior,
+              targetPrice,
+              inputMarketHashName: input.marketHashName,
+              inputPrice: price,
+              totalInputCost,
+              ratioPercent,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  const entries = Array.from(bestByTarget.values()).sort(
+    (a, b) => b.ratioPercent - a.ratioPercent,
+  );
+  return { entries, warnings };
+};
+
+const CollectionAnalyzer: React.FC = () => {
+  const { collections, loading, error, load } = useSteamCollections();
+  const [filter, setFilter] = React.useState("");
+  const [selectedTag, setSelectedTag] = React.useState<string | null>(null);
+  const [analysis, setAnalysis] = React.useState<CollectionAnalysis | null>(null);
+  const [analysisError, setAnalysisError] = React.useState<string | null>(null);
+  const [analysisLoading, setAnalysisLoading] = React.useState(false);
+
+  React.useEffect(() => {
+    load().catch(() => undefined);
+  }, [load]);
+
+  React.useEffect(() => {
+    if (!collections.length) return;
+    if (selectedTag && collections.some((collection) => collection.tag === selectedTag)) {
+      return;
+    }
+    setSelectedTag(collections[0]?.tag ?? null);
+  }, [collections, selectedTag]);
+
+  React.useEffect(() => {
+    if (!selectedTag) {
+      setAnalysis(null);
+      setAnalysisError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setAnalysis(null);
+    setAnalysisError(null);
+    setAnalysisLoading(true);
+
+    (async () => {
+      try {
+        const result = await analyzeCollection(selectedTag);
+        if (cancelled) return;
+        setAnalysis(result);
+      } catch (error: any) {
+        if (cancelled) return;
+        setAnalysisError(String(error?.message || error));
+      } finally {
+        if (cancelled) return;
+        setAnalysisLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedTag]);
+
+  const filteredCollections = React.useMemo(() => {
+    if (!filter.trim()) return collections;
+    const needle = filter.trim().toLowerCase();
+    return collections.filter((collection) =>
+      collection.name.toLowerCase().includes(needle) || collection.tag.toLowerCase().includes(needle),
+    );
+  }, [collections, filter]);
+
+  const activeCollection = React.useMemo(
+    () => collections.find((collection) => collection.tag === selectedTag) ?? null,
+    [collections, selectedTag],
+  );
+
+  const maxRatio = React.useMemo(() => {
+    if (!analysis?.entries?.length) return 0;
+    return analysis.entries.reduce((max, entry) => Math.max(max, entry.ratioPercent), 0);
+  }, [analysis]);
+
+  return (
+    <div className="collection-analyzer">
+      <div>
+        <h2 className="h4">Анализ коллекций</h2>
+        <p className="text-secondary">
+          Выберите коллекцию, чтобы найти самые выгодные варианты trade-up. Сравнение строится по
+          соотношению цены результата к стоимости 10 входных скинов.
+        </p>
+      </div>
+      <div className="collection-analyzer__layout">
+        <div className="collection-analyzer__collections">
+          <div className="collection-analyzer__collections-search">
+            <input
+              type="search"
+              className="form-control form-control-sm"
+              placeholder="Поиск коллекции"
+              value={filter}
+              onChange={(event) => setFilter(event.target.value)}
+            />
+          </div>
+          <div className="collection-analyzer__collections-list">
+            {loading && <div className="text-secondary small">Загрузка…</div>}
+            {!loading && error && <div className="collection-analyzer__error">{error}</div>}
+            {!loading && !error && !filteredCollections.length && (
+              <div className="collection-analyzer__empty">Коллекции не найдены.</div>
+            )}
+            {!loading && !error &&
+              filteredCollections.map((collection) => {
+                const isActive = collection.tag === selectedTag;
+                return (
+                  <button
+                    key={collection.tag}
+                    type="button"
+                    className={`btn btn-sm ${isActive ? "btn-primary" : "btn-outline-light"}`}
+                    onClick={() => setSelectedTag(collection.tag)}
+                  >
+                    <div className="fw-semibold">{collection.name}</div>
+                    <div className="small text-secondary">{collection.count} предметов</div>
+                  </button>
+                );
+              })}
+          </div>
+        </div>
+        <div className="collection-analyzer__results">
+          <div className="collection-analyzer__summary">
+            <div className="h5 mb-0">{activeCollection?.name ?? "Коллекция"}</div>
+            {activeCollection && (
+              <span className="text-secondary">
+                Steam tag: {activeCollection.tag} • {activeCollection.count} предметов
+              </span>
+            )}
+          </div>
+          {analysisLoading && <div className="text-secondary">Подбор контрактов…</div>}
+          {!analysisLoading && analysisError && (
+            <div className="collection-analyzer__error">{analysisError}</div>
+          )}
+          {!analysisLoading && !analysisError && !analysis?.entries.length && (
+            <div className="collection-analyzer__empty">
+              Не удалось подобрать контракты: нет данных о ценах.
+            </div>
+          )}
+          {!analysisLoading && !analysisError && analysis?.entries.length ? (
+            <div className="collection-chart">
+              {analysis.entries.map((entry) => {
+                const width = maxRatio > 0 ? Math.max((entry.ratioPercent / maxRatio) * 100, 2) : 0;
+                return (
+                  <div key={entry.key} className="collection-chart__row">
+                    <div className="collection-chart__label">
+                      <div className="fw-semibold">{entry.targetMarketHashName}</div>
+                      <div className="collection-chart__meta">
+                        {TARGET_RARITY_TITLES[entry.targetRarity]}
+                        {entry.inputRarity ? ` • вход: ${entry.inputRarity}` : ""}
+                      </div>
+                      <div className="collection-chart__inputs">
+                        Лучший вход: {entry.inputMarketHashName} • {formatCurrency(entry.inputPrice)} × 10 ={" "}
+                        {formatCurrency(entry.totalInputCost)}
+                      </div>
+                    </div>
+                    <div className="collection-chart__bar">
+                      <div className="collection-chart__bar-fill" style={{ width: `${width}%` }} />
+                      <div className="collection-chart__value">{entry.ratioPercent.toFixed(1)}%</div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : null}
+          {analysis?.warnings?.length ? (
+            <div className="text-warning small">
+              {analysis.warnings.map((warning, index) => (
+                <div key={index}>{warning}</div>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CollectionAnalyzer;

--- a/client/src/modules/collections/index.ts
+++ b/client/src/modules/collections/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CollectionAnalyzer";

--- a/client/src/modules/tradeups/services/api.ts
+++ b/client/src/modules/tradeups/services/api.ts
@@ -65,6 +65,10 @@ export interface CollectionInputsResponse {
   inputs: CollectionInputSummary[];
 }
 
+export interface CollectionRaritiesResponse {
+  rarities: TargetRarity[];
+}
+
 export interface SyncJobProgress {
   totalCollections: number;
   syncedCollections: number;
@@ -230,6 +234,18 @@ export async function fetchCollectionInputs(
     throw new Error(`HTTP ${response.status}`);
   }
   return (await response.json()) as CollectionInputsResponse;
+}
+
+/** Возвращает список редкостей, доступных для выбранной коллекции. */
+export async function fetchCollectionRarities(collectionTag: string) {
+  const response = await fetch(
+    `/api/tradeups/collections/${encodeURIComponent(collectionTag)}/rarities`,
+  );
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  const payload = (await response.json()) as CollectionRaritiesResponse;
+  return payload.rarities ?? [];
 }
 
 /** Отправляет состав trade-up'а на сервер для расчёта EV и вероятностей. */

--- a/server/src/database/collections.ts
+++ b/server/src/database/collections.ts
@@ -9,6 +9,7 @@ import type {
   TargetRarity,
   InputRarity,
 } from "../modules/tradeups/types";
+import { TARGET_RARITIES } from "../modules/tradeups/types";
 import { baseFromMarketHash } from "../modules/skins/service";
 
 const normalizeRarity = (rarity: string) => rarity.trim();
@@ -139,6 +140,35 @@ export const getCollectionTargetsFromDb = async (
     };
   } catch (error) {
     return null;
+  }
+};
+
+export const getCollectionRaritiesFromDb = async (
+  collectionTag: string,
+): Promise<TargetRarity[]> => {
+  try {
+    const result = await prisma.skin.groupBy({
+      by: ["rarity"],
+      where: {
+        collection: { steamTag: collectionTag },
+        isSouvenir: false,
+        isStatTrak: false,
+      },
+    });
+    if (!result.length) return [];
+
+    const allowed = new Set(TARGET_RARITIES);
+    const rarities: TargetRarity[] = [];
+    for (const entry of result) {
+      const value = String(entry.rarity ?? "").trim();
+      if (!value) continue;
+      if (allowed.has(value as TargetRarity)) {
+        rarities.push(value as TargetRarity);
+      }
+    }
+    return rarities;
+  } catch (error) {
+    return [];
   }
 };
 

--- a/server/src/modules/tradeups/router.ts
+++ b/server/src/modules/tradeups/router.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import {
   calculateTradeup,
   checkTradeupAvailability,
+  fetchCollectionAvailableRarities,
   fetchCollectionInputs,
   fetchCollectionTargets,
   fetchSteamCollections,
@@ -171,6 +172,20 @@ export const createTradeupsRouter = () => {
       return response.json({ job });
     } catch (error) {
       return response.status(500).json({ error: String(error) });
+    }
+  });
+
+  /** Список доступных редкостей коллекции для анализа trade-up. */
+  router.get("/collections/:collectionTag/rarities", async (request, response) => {
+    const collectionTag = String(request.params?.collectionTag ?? "").trim();
+    if (!collectionTag) {
+      return response.status(400).json({ error: "collectionTag is required" });
+    }
+    try {
+      const rarities = await fetchCollectionAvailableRarities(collectionTag);
+      response.json({ rarities });
+    } catch (error) {
+      response.status(503).json({ error: String(error) });
     }
   });
 


### PR DESCRIPTION
## Summary
- add a new Collection Analyzer tab that automatically loads collections
- rank trade-up outcomes by the ratio of result price to the cost of ten inputs and visualize them on a chart
- update the main navigation to surface the analyzer alongside existing tools

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fa763ffdfc8332a34d7d300e78bf50