### PR TITLE
Group collection analyzer results by profit probability

### DIFF
--- a/client/src/modules/collections/CollectionAnalyzer.css
+++ b/client/src/modules/collections/CollectionAnalyzer.css
@@ -138,12 +138,42 @@
   margin: 0.15rem 0 0 1.1rem;
   padding: 0;
   display: grid;
-  gap: 0.15rem;
+  gap: 0.35rem;
   list-style: disc;
 }
 
 .collection-chart__outcomes-list li {
   margin: 0;
+}
+
+.collection-chart__outcome {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.collection-chart__outcome-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.25rem;
+}
+
+.collection-chart__outcome-name {
+  font-weight: 600;
+}
+
+.collection-chart__outcome-profit {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.collection-chart__outcome-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.75rem;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.65);
 }
 
 .collection-analyzer__empty {

--- a/client/src/modules/collections/CollectionAnalyzer.css
+++ b/client/src/modules/collections/CollectionAnalyzer.css
@@ -61,6 +61,26 @@
   gap: 0.75rem;
 }
 
+.collection-chart__group {
+  display: grid;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.collection-chart__group:first-child {
+  border-top: none;
+  padding-top: 0;
+}
+
+.collection-chart__group-title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgba(255, 255, 255, 0.7);
+}
+
 .collection-chart__row {
   display: grid;
   gap: 0.5rem;
@@ -101,6 +121,29 @@
 .collection-chart__inputs {
   font-size: 0.8rem;
   color: rgba(255, 255, 255, 0.6);
+}
+
+.collection-chart__probability {
+  margin-top: 0.35rem;
+}
+
+.collection-chart__outcomes {
+  margin-top: 0.35rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.collection-chart__outcomes-list {
+  margin: 0.15rem 0 0 1.1rem;
+  padding: 0;
+  display: grid;
+  gap: 0.15rem;
+  list-style: disc;
+}
+
+.collection-chart__outcomes-list li {
+  margin: 0;
 }
 
 .collection-analyzer__empty {


### PR DESCRIPTION
## Summary
- compute profit probabilities for each planned trade-up, including ratios for all possible outcomes
- group collection analyzer results by shared profit chance and show alternate drops with profit or loss percentages
- style the collection chart sections for the new grouped layout and outcome list

## Testing
- npm run build *(fails: existing TypeScript errors in trade-up builder files)*

------
https://chatgpt.com/codex/tasks/task_e_68fabc73c0a4833285977e86dcbcc6bf