### PR TITLE
Show all possible target skins in collection analyzer

### DIFF
--- a/client/src/modules/collections/CollectionAnalyzer.css
+++ b/client/src/modules/collections/CollectionAnalyzer.css
@@ -124,6 +124,11 @@
   color: rgba(255, 255, 255, 0.6);
 }
 
+.collection-chart__profit {
+  font-size: 0.85rem;
+  margin-top: 0.15rem;
+}
+
 .collection-analyzer__empty {
   color: rgba(255, 255, 255, 0.65);
 }

--- a/client/src/modules/collections/CollectionAnalyzer.css
+++ b/client/src/modules/collections/CollectionAnalyzer.css
@@ -98,6 +98,27 @@
   color: rgba(255, 255, 255, 0.65);
 }
 
+.collection-chart__targets {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.collection-chart__targets-list {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.collection-chart__target {
+  display: inline-flex;
+  gap: 0.3rem;
+  align-items: baseline;
+}
+
+.collection-chart__target--primary {
+  font-weight: 600;
+}
+
 .collection-chart__inputs {
   font-size: 0.8rem;
   color: rgba(255, 255, 255, 0.6);


### PR DESCRIPTION
## Summary
- collect all possible outputs for a target rarity when analyzing a collection
- surface the list of possible target skins in the analyzer UI and highlight the planned target
- add styling for the expanded targets list in the collection chart rows

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fac9d9722883328c79591d78252d38