### PR TITLE
Add bulk analysis controls for collections

### DIFF
--- a/client/src/modules/collections/CollectionAnalyzer.css
+++ b/client/src/modules/collections/CollectionAnalyzer.css
@@ -137,6 +137,43 @@
 .collection-chart__inputs {
   font-size: 0.8rem;
   color: rgba(255, 255, 255, 0.6);
+  display: grid;
+  gap: 0.4rem;
+}
+
+.collection-chart__inputs-summary {
+  line-height: 1.4;
+}
+
+.collection-chart__slots {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.collection-chart__slot {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  gap: 0.5rem;
+  align-items: baseline;
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.collection-chart__slot-index {
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.collection-chart__slot-name {
+  word-break: break-word;
+}
+
+.collection-chart__slot-price,
+.collection-chart__slot-float {
+  white-space: nowrap;
 }
 
 .collection-chart__profit {
@@ -169,6 +206,14 @@
 }
 
 .collection-analyzer__bulk-entry {
+  display: grid;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: 0.75rem;
+}
+
+.collection-analyzer__bulk-entry-head {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
@@ -195,5 +240,86 @@
   display: inline-flex;
   align-items: center;
   gap: 0.35rem;
+}
+
+.collection-analyzer__bulk-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.collection-analyzer__bulk-filters .form-control {
+  width: auto;
+  min-width: 150px;
+}
+
+.collection-analyzer__bulk-filters .btn {
+  white-space: nowrap;
+}
+
+.collection-analyzer__bulk-targets {
+  display: grid;
+  gap: 0.3rem;
+}
+
+.collection-analyzer__bulk-targets-title {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.collection-analyzer__bulk-targets-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.collection-analyzer__bulk-target {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  align-items: baseline;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.8rem;
+}
+
+.collection-analyzer__bulk-target--primary {
+  background: rgba(13, 110, 253, 0.35);
+  font-weight: 600;
+}
+
+.collection-analyzer__bulk-inputs {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.collection-analyzer__bulk-input {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  gap: 0.5rem;
+  align-items: baseline;
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.collection-analyzer__bulk-input-index {
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.collection-analyzer__bulk-input-name {
+  word-break: break-word;
+}
+
+.collection-analyzer__bulk-input-price,
+.collection-analyzer__bulk-input-float {
+  white-space: nowrap;
 }
 

--- a/client/src/modules/collections/CollectionAnalyzer.css
+++ b/client/src/modules/collections/CollectionAnalyzer.css
@@ -29,6 +29,21 @@
   width: 100%;
 }
 
+.collection-analyzer__collections-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.collection-analyzer__collections-actions .btn {
+  width: 100%;
+}
+
+.collection-analyzer__bulk-status {
+  font-size: 0.8rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
 .collection-analyzer__collections-list {
   display: flex;
   flex-direction: column;
@@ -135,5 +150,50 @@
 
 .collection-analyzer__error {
   color: #ffb3b3;
+}
+
+.collection-analyzer__bulk-results {
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  margin-top: 1.5rem;
+  padding-top: 1.25rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.collection-analyzer__bulk-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.collection-analyzer__bulk-entry {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: baseline;
+  justify-content: space-between;
+}
+
+.collection-analyzer__bulk-entry-info {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.collection-analyzer__bulk-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.collection-analyzer__bulk-metric {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
 }
 

--- a/client/src/modules/collections/CollectionAnalyzer.tsx
+++ b/client/src/modules/collections/CollectionAnalyzer.tsx
@@ -42,6 +42,13 @@ interface CollectionAnalysisInputEntry {
   maxFloat: number | null;
 }
 
+interface CollectionAnalysisInputSlot {
+  slot: number;
+  marketHashName: string;
+  price: number;
+  float: number | null;
+}
+
 interface CollectionAnalysisTargetOption {
   marketHashName: string;
   price: number;
@@ -58,6 +65,7 @@ interface CollectionAnalysisEntry {
   targetPrice: number;
   possibleTargets: CollectionAnalysisTargetOption[];
   inputs: CollectionAnalysisInputEntry[];
+  inputSlots: CollectionAnalysisInputSlot[];
   totalInputCost: number;
   ratioPercent: number;
   profitProbability: number | null;
@@ -85,6 +93,13 @@ interface BulkAnalysisTopEntry {
   collectionTag: string;
   collectionName: string;
   entry: CollectionAnalysisEntry;
+}
+
+interface BulkFilterState {
+  search: string;
+  minRoi: string;
+  minPrice: string;
+  minProfit: string;
 }
 
 interface RarityPreparation {
@@ -331,14 +346,21 @@ const buildPlanRowsForTarget = ({
 
 const summarizePlanRows = (
   planRows: TradeupInputFormRow[],
-): { inputs: CollectionAnalysisInputEntry[]; totalInputCost: number } | null => {
+):
+  | {
+      inputs: CollectionAnalysisInputEntry[];
+      slots: CollectionAnalysisInputSlot[];
+      totalInputCost: number;
+    }
+  | null => {
   const inputsByName = new Map<
     string,
     { count: number; total: number; minFloat: number | null; maxFloat: number | null }
   >();
   let totalInputCost = 0;
+  const slots: CollectionAnalysisInputSlot[] = [];
 
-  for (const row of planRows) {
+  for (const [index, row] of planRows.entries()) {
     const price = Number.parseFloat(row.price);
     if (!Number.isFinite(price) || price <= 0) {
       return null;
@@ -347,6 +369,12 @@ const summarizePlanRows = (
     totalInputCost += price;
 
     const floatValue = Number.parseFloat(row.float);
+    slots.push({
+      slot: index + 1,
+      marketHashName: row.marketHashName,
+      price,
+      float: Number.isFinite(floatValue) ? floatValue : null,
+    });
     const current =
       inputsByName.get(row.marketHashName) ??
       { count: 0, total: 0, minFloat: null, maxFloat: null };
@@ -385,7 +413,9 @@ const summarizePlanRows = (
     return a.marketHashName.localeCompare(b.marketHashName, "ru");
   });
 
-  return { inputs, totalInputCost };
+  slots.sort((a, b) => a.slot - b.slot);
+
+  return { inputs, totalInputCost, slots };
 };
 
 const buildTradeupPayload = (
@@ -545,6 +575,7 @@ const buildEntryForTarget = async ({
     targetPrice,
     possibleTargets: prioritizedTargets,
     inputs: summary.inputs,
+    inputSlots: summary.slots,
     totalInputCost: summary.totalInputCost,
     ratioPercent,
     profitProbability,
@@ -701,6 +732,12 @@ const CollectionAnalyzer: React.FC = () => {
   const [bulkResults, setBulkResults] = React.useState<BulkCollectionAnalysisResult[]>([]);
   const [bulkRunning, setBulkRunning] = React.useState(false);
   const [bulkProgress, setBulkProgress] = React.useState<BulkAnalysisProgress | null>(null);
+  const [bulkFilter, setBulkFilter] = React.useState<BulkFilterState>({
+    search: "",
+    minRoi: "",
+    minPrice: "",
+    minProfit: "",
+  });
 
   React.useEffect(() => {
     load().catch(() => undefined);
@@ -783,6 +820,14 @@ const CollectionAnalyzer: React.FC = () => {
   const bulkErrors = React.useMemo(() => bulkResults.filter((entry) => entry.error), [bulkResults]);
 
   const bulkTopEntries = React.useMemo(() => {
+    const minRoi = Number.parseFloat(bulkFilter.minRoi.replace(",", "."));
+    const hasMinRoi = Number.isFinite(minRoi);
+    const minPrice = Number.parseFloat(bulkFilter.minPrice.replace(",", "."));
+    const hasMinPrice = Number.isFinite(minPrice);
+    const minProfitPercent = Number.parseFloat(bulkFilter.minProfit.replace(",", "."));
+    const hasMinProfit = Number.isFinite(minProfitPercent);
+    const searchNeedle = bulkFilter.search.trim().toLowerCase();
+
     const aggregated: BulkAnalysisTopEntry[] = [];
     for (const result of bulkResults) {
       if (!result.analysis?.entries?.length) continue;
@@ -795,7 +840,36 @@ const CollectionAnalyzer: React.FC = () => {
       }
     }
 
-    aggregated.sort((a, b) => {
+    const filtered = aggregated.filter((item) => {
+      if (searchNeedle) {
+        const matchesSearch =
+          item.collectionName.toLowerCase().includes(searchNeedle) ||
+          item.collectionTag.toLowerCase().includes(searchNeedle) ||
+          item.entry.targetMarketHashName.toLowerCase().includes(searchNeedle);
+        if (!matchesSearch) {
+          return false;
+        }
+      }
+
+      if (hasMinRoi && item.entry.ratioPercent < minRoi) {
+        return false;
+      }
+
+      if (hasMinPrice && item.entry.targetPrice < minPrice) {
+        return false;
+      }
+
+      if (hasMinProfit) {
+        const probabilityPercent = (item.entry.profitProbability ?? 0) * 100;
+        if (probabilityPercent < minProfitPercent) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+
+    filtered.sort((a, b) => {
       if (b.entry.ratioPercent !== a.entry.ratioPercent) {
         return b.entry.ratioPercent - a.entry.ratioPercent;
       }
@@ -807,8 +881,21 @@ const CollectionAnalyzer: React.FC = () => {
       return a.entry.targetMarketHashName.localeCompare(b.entry.targetMarketHashName, "ru");
     });
 
-    return aggregated.slice(0, 15);
-  }, [bulkResults]);
+    return filtered.slice(0, 30);
+  }, [bulkResults, bulkFilter]);
+
+  const handleBulkFilterChange = React.useCallback(
+    (key: keyof BulkFilterState) =>
+      (event: React.ChangeEvent<HTMLInputElement>) => {
+        const { value } = event.target;
+        setBulkFilter((previous) => ({ ...previous, [key]: value }));
+      },
+    [setBulkFilter],
+  );
+
+  const handleBulkFilterReset = React.useCallback(() => {
+    setBulkFilter({ search: "", minRoi: "", minPrice: "", minProfit: "" });
+  }, [setBulkFilter]);
 
   const activeCollection = React.useMemo(
     () => collections.find((collection) => collection.tag === selectedTag) ?? null,
@@ -947,19 +1034,39 @@ const CollectionAnalyzer: React.FC = () => {
                           {entry.inputRarity ? ` • вход: ${entry.inputRarity}` : ""}
                         </div>
                         <div className="collection-chart__inputs">
-                          Лучший вход:
-                          {entry.inputs.map((input, index) => {
-                            const floatLabel = formatFloatRange(input.minFloat, input.maxFloat);
-                            return (
-                              <React.Fragment key={`${entry.key}:${input.marketHashName}:${index}`}>
-                                {index > 0 ? ", " : " "}
-                                {input.marketHashName} × {input.count} ({formatCurrency(input.unitPrice)} за слот
-                                {floatLabel ? `, float ${floatLabel}` : ""})
-                              </React.Fragment>
-                            );
-                          })}
-                          {" • Σ "}
-                          {formatCurrency(entry.totalInputCost)}
+                          <div className="collection-chart__inputs-summary">
+                            Лучший вход:
+                            {entry.inputs.map((input, index) => {
+                              const floatLabel = formatFloatRange(input.minFloat, input.maxFloat);
+                              return (
+                                <React.Fragment key={`${entry.key}:${input.marketHashName}:${index}`}>
+                                  {index > 0 ? ", " : " "}
+                                  {input.marketHashName} × {input.count} ({formatCurrency(input.unitPrice)} за слот
+                                  {floatLabel ? `, float ${floatLabel}` : ""})
+                                </React.Fragment>
+                              );
+                            })}
+                            {" • Σ "}
+                            {formatCurrency(entry.totalInputCost)}
+                          </div>
+                          {entry.inputSlots.length ? (
+                            <ol className="collection-chart__slots">
+                              {entry.inputSlots.map((slot) => (
+                                <li key={`${entry.key}:slot:${slot.slot}`} className="collection-chart__slot">
+                                  <span className="collection-chart__slot-index">#{slot.slot}</span>
+                                  <span className="collection-chart__slot-name">{slot.marketHashName}</span>
+                                  <span className="collection-chart__slot-price">
+                                    {formatCurrency(slot.price)}
+                                  </span>
+                                  {slot.float != null ? (
+                                    <span className="collection-chart__slot-float">
+                                      float {formatFloat(slot.float)}
+                                    </span>
+                                  ) : null}
+                                </li>
+                              ))}
+                            </ol>
+                          ) : null}
                         </div>
                         {entry.profitProbability != null ? (
                           <div
@@ -999,33 +1106,133 @@ const CollectionAnalyzer: React.FC = () => {
               </div>
             </div>
             {bulkTopEntries.length ? (
-              <ul className="collection-analyzer__bulk-list">
-                {bulkTopEntries.map((item) => (
-                  <li key={`${item.collectionTag}:${item.entry.key}`}>
-                    <div className="collection-analyzer__bulk-entry">
-                      <div className="collection-analyzer__bulk-entry-info">
-                        <div className="fw-semibold">{item.collectionName}</div>
-                        <div className="text-secondary small">
-                          {item.entry.targetMarketHashName} • {TARGET_RARITY_TITLES[item.entry.targetRarity]}
+              <>
+                <div className="collection-analyzer__bulk-filters">
+                  <input
+                    type="search"
+                    className="form-control form-control-sm"
+                    placeholder="Фильтр по коллекции или скину"
+                    value={bulkFilter.search}
+                    onChange={handleBulkFilterChange("search")}
+                  />
+                  <input
+                    type="text"
+                    inputMode="decimal"
+                    className="form-control form-control-sm"
+                    placeholder="Мин. ROI %"
+                    value={bulkFilter.minRoi}
+                    onChange={handleBulkFilterChange("minRoi")}
+                  />
+                  <input
+                    type="text"
+                    inputMode="decimal"
+                    className="form-control form-control-sm"
+                    placeholder="Мин. цена результата"
+                    value={bulkFilter.minPrice}
+                    onChange={handleBulkFilterChange("minPrice")}
+                  />
+                  <input
+                    type="text"
+                    inputMode="decimal"
+                    className="form-control form-control-sm"
+                    placeholder="Мин. шанс профита %"
+                    value={bulkFilter.minProfit}
+                    onChange={handleBulkFilterChange("minProfit")}
+                  />
+                  <button
+                    type="button"
+                    className="btn btn-outline-light btn-sm"
+                    onClick={handleBulkFilterReset}
+                  >
+                    Сбросить
+                  </button>
+                </div>
+                <ul className="collection-analyzer__bulk-list">
+                  {bulkTopEntries.map((item) => {
+                    const targetsToShow = item.entry.possibleTargets.length
+                      ? item.entry.possibleTargets
+                      : ([
+                          {
+                            marketHashName: item.entry.targetMarketHashName,
+                            price: item.entry.targetPrice,
+                            exterior: item.entry.targetExterior,
+                          },
+                        ] as CollectionAnalysisTargetOption[]);
+
+                    return (
+                      <li key={`${item.collectionTag}:${item.entry.key}`}>
+                        <div className="collection-analyzer__bulk-entry">
+                          <div className="collection-analyzer__bulk-entry-head">
+                            <div className="collection-analyzer__bulk-entry-info">
+                              <div className="fw-semibold">{item.collectionName}</div>
+                              <div className="text-secondary small">
+                                {item.entry.targetMarketHashName} • {TARGET_RARITY_TITLES[item.entry.targetRarity]}
+                              </div>
+                            </div>
+                            <div className="collection-analyzer__bulk-metrics">
+                              <span className="collection-analyzer__bulk-metric">
+                                {formatCurrency(item.entry.targetPrice)}
+                              </span>
+                              <span className="collection-analyzer__bulk-metric">
+                                ROI {item.entry.ratioPercent.toFixed(1)}%
+                              </span>
+                              <span className="collection-analyzer__bulk-metric">
+                                Σ {formatCurrency(item.entry.totalInputCost)}
+                              </span>
+                              {item.entry.profitProbability != null ? (
+                                <span className="collection-analyzer__bulk-metric">
+                                  Профит {formatProbabilityPercent(item.entry.profitProbability)}
+                                </span>
+                              ) : null}
+                            </div>
+                          </div>
+                          <div className="collection-analyzer__bulk-targets">
+                            <div className="collection-analyzer__bulk-targets-title">Возможные результаты:</div>
+                            <div className="collection-analyzer__bulk-targets-list">
+                              {targetsToShow.map((target) => (
+                                <span
+                                  key={`${item.entry.key}:target:${target.marketHashName}`}
+                                  className={`collection-analyzer__bulk-target${
+                                    target.marketHashName === item.entry.targetMarketHashName
+                                      ? " collection-analyzer__bulk-target--primary"
+                                      : ""
+                                  }`}
+                                >
+                                  {target.marketHashName}
+                                  <span className="text-secondary ms-1">
+                                    ({formatCurrency(target.price)})
+                                  </span>
+                                </span>
+                              ))}
+                            </div>
+                          </div>
+                          {item.entry.inputSlots.length ? (
+                            <ol className="collection-analyzer__bulk-inputs">
+                              {item.entry.inputSlots.map((slot) => (
+                                <li
+                                  key={`${item.entry.key}:bulk-slot:${slot.slot}`}
+                                  className="collection-analyzer__bulk-input"
+                                >
+                                  <span className="collection-analyzer__bulk-input-index">#{slot.slot}</span>
+                                  <span className="collection-analyzer__bulk-input-name">{slot.marketHashName}</span>
+                                  <span className="collection-analyzer__bulk-input-price">
+                                    {formatCurrency(slot.price)}
+                                  </span>
+                                  {slot.float != null ? (
+                                    <span className="collection-analyzer__bulk-input-float">
+                                      float {formatFloat(slot.float)}
+                                    </span>
+                                  ) : null}
+                                </li>
+                              ))}
+                            </ol>
+                          ) : null}
                         </div>
-                      </div>
-                      <div className="collection-analyzer__bulk-metrics">
-                        <span className="collection-analyzer__bulk-metric">
-                          {formatCurrency(item.entry.targetPrice)}
-                        </span>
-                        <span className="collection-analyzer__bulk-metric">
-                          ROI {item.entry.ratioPercent.toFixed(1)}%
-                        </span>
-                        {item.entry.profitProbability != null ? (
-                          <span className="collection-analyzer__bulk-metric">
-                            Профит {formatProbabilityPercent(item.entry.profitProbability)}
-                          </span>
-                        ) : null}
-                      </div>
-                    </div>
-                  </li>
-                ))}
-              </ul>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </>
             ) : (
               <div className="text-secondary small">
                 Не удалось подобрать выгодные контракты для выбранных коллекций.

--- a/client/src/modules/collections/CollectionAnalyzer.tsx
+++ b/client/src/modules/collections/CollectionAnalyzer.tsx
@@ -10,6 +10,7 @@ import {
   type TradeupInputPayload,
   type TradeupOutcomeResponse,
   type SteamCollectionSummary,
+  type TradeupTargetOverridePayload,
 } from "../tradeups/services/api";
 import { planRowsForCollection } from "../tradeups/hooks/rowPlanning";
 import { useSteamCollections } from "../tradeups/hooks/useSteamCollections";
@@ -108,6 +109,7 @@ interface RarityPreparation {
   pricedInputs: CollectionInputSummary[];
   collectionId: string | null;
   targetPriceLookup: Map<string, number>;
+  targetOverrides: TradeupTargetOverridePayload[];
 }
 
 interface TradeupEvaluationResult {
@@ -198,6 +200,37 @@ const prioritizeTargetOptions = (
   const primary = options.filter((option) => option.marketHashName === primaryMarketHashName);
   const rest = options.filter((option) => option.marketHashName !== primaryMarketHashName);
   return [...primary, ...rest];
+};
+
+const buildTargetOverrides = (
+  collectionId: string | null,
+  collectionTag: string,
+  targets: CollectionTargetsResponse["targets"],
+): TradeupTargetOverridePayload[] => {
+  const overrides: TradeupTargetOverridePayload[] = [];
+
+  targets.forEach((target) => {
+    target.exteriors.forEach((exterior) => {
+      const minFloat =
+        typeof exterior.minFloat === "number" ? exterior.minFloat : null;
+      const maxFloat =
+        typeof exterior.maxFloat === "number" ? exterior.maxFloat : null;
+      const price = typeof exterior.price === "number" ? exterior.price : null;
+
+      overrides.push({
+        collectionId,
+        collectionTag,
+        baseName: target.baseName,
+        exterior: exterior.exterior,
+        marketHashName: exterior.marketHashName,
+        minFloat,
+        maxFloat,
+        price,
+      });
+    });
+  });
+
+  return overrides;
 };
 
 const buildTargetOptionsFromOutcomes = (
@@ -296,6 +329,11 @@ const prepareRarityData = async (
   const targetPriceLookup = new Map(
     targetOptions.map((option) => [option.marketHashName, option.price] as const),
   );
+  const targetOverrides = buildTargetOverrides(
+    effectiveCollectionId,
+    collectionTag,
+    targets,
+  );
 
   return {
     targets,
@@ -303,6 +341,7 @@ const prepareRarityData = async (
     pricedInputs,
     collectionId: effectiveCollectionId,
     targetPriceLookup,
+    targetOverrides,
   };
 };
 
@@ -434,12 +473,18 @@ const buildTradeupPayload = (
       return null;
     }
 
+    const priceText = row.price.replace(/\s+/g, "");
+    const normalizedPriceText = priceText.replace(/[^0-9.,-]/g, "");
+    const priceValue = Number.parseFloat(normalizedPriceText.replace(",", "."));
+    const priceOverrideNet = Number.isFinite(priceValue) ? priceValue : null;
+
     payload.push({
       marketHashName: row.marketHashName,
       float: floatValue,
       collectionId,
       minFloat: floatValue,
       maxFloat: floatValue,
+      priceOverrideNet,
     });
   }
 
@@ -480,6 +525,7 @@ const evaluateTradeupOutcomes = async (
   targetRarity: TargetRarity,
   targetPriceLookup: Map<string, number>,
   totalInputCost: number,
+  targetOverrides: TradeupTargetOverridePayload[],
 ): Promise<TradeupEvaluationResult> => {
   if (!payload || !targetCollectionId) {
     return { targets: [], profitProbability: null };
@@ -490,6 +536,7 @@ const evaluateTradeupOutcomes = async (
       inputs: payload,
       targetCollectionIds: [targetCollectionId],
       targetRarity,
+      targetOverrides,
     });
 
     const resolvedTargets = buildTargetOptionsFromOutcomes(
@@ -552,6 +599,7 @@ const buildEntryForTarget = async ({
     targetRarity,
     rarityData.targetPriceLookup,
     summary.totalInputCost,
+    rarityData.targetOverrides,
   );
 
   const prioritizedTargets = resolvedTargets.length

--- a/client/src/modules/collections/CollectionAnalyzer.tsx
+++ b/client/src/modules/collections/CollectionAnalyzer.tsx
@@ -9,6 +9,7 @@ import {
   type TargetRarity,
   type TradeupInputPayload,
   type TradeupOutcomeResponse,
+  type SteamCollectionSummary,
 } from "../tradeups/services/api";
 import { planRowsForCollection } from "../tradeups/hooks/rowPlanning";
 import { useSteamCollections } from "../tradeups/hooks/useSteamCollections";
@@ -65,6 +66,25 @@ interface CollectionAnalysisEntry {
 interface CollectionAnalysis {
   entries: CollectionAnalysisEntry[];
   warnings: string[];
+}
+
+interface BulkCollectionAnalysisResult {
+  collection: SteamCollectionSummary;
+  analysis: CollectionAnalysis | null;
+  error: string | null;
+}
+
+interface BulkAnalysisProgress {
+  total: number;
+  completed: number;
+  currentTag: string | null;
+  currentName: string | null;
+}
+
+interface BulkAnalysisTopEntry {
+  collectionTag: string;
+  collectionName: string;
+  entry: CollectionAnalysisEntry;
 }
 
 interface RarityPreparation {
@@ -678,6 +698,9 @@ const CollectionAnalyzer: React.FC = () => {
   const [filter, setFilter] = React.useState("");
   const [selectedTag, setSelectedTag] = React.useState<string | null>(null);
   const { analysis, analysisError, analysisLoading } = useCollectionAnalysis(selectedTag);
+  const [bulkResults, setBulkResults] = React.useState<BulkCollectionAnalysisResult[]>([]);
+  const [bulkRunning, setBulkRunning] = React.useState(false);
+  const [bulkProgress, setBulkProgress] = React.useState<BulkAnalysisProgress | null>(null);
 
   React.useEffect(() => {
     load().catch(() => undefined);
@@ -698,6 +721,94 @@ const CollectionAnalyzer: React.FC = () => {
       collection.name.toLowerCase().includes(needle) || collection.tag.toLowerCase().includes(needle),
     );
   }, [collections, filter]);
+
+  const handleAnalyzeAll = React.useCallback(async () => {
+    if (!collections.length || bulkRunning) {
+      return;
+    }
+
+    setBulkRunning(true);
+    setBulkResults([]);
+    setBulkProgress({ total: collections.length, completed: 0, currentTag: null, currentName: null });
+
+    const results: BulkCollectionAnalysisResult[] = [];
+
+    try {
+      for (const collection of collections) {
+        setBulkProgress((previous) =>
+          previous
+            ? {
+                ...previous,
+                currentTag: collection.tag,
+                currentName: collection.name,
+              }
+            : previous,
+        );
+
+        try {
+          const result = await analyzeCollection(collection.tag);
+          results.push({ collection, analysis: result, error: null });
+        } catch (error: any) {
+          results.push({
+            collection,
+            analysis: null,
+            error: String(error?.message || error),
+          });
+        }
+
+        setBulkResults([...results]);
+        setBulkProgress((previous) =>
+          previous
+            ? {
+                ...previous,
+                completed: previous.completed + 1,
+              }
+            : previous,
+        );
+      }
+    } finally {
+      setBulkProgress((previous) =>
+        previous
+          ? {
+              ...previous,
+              currentTag: null,
+              currentName: null,
+            }
+          : previous,
+      );
+      setBulkRunning(false);
+    }
+  }, [collections, bulkRunning]);
+
+  const bulkErrors = React.useMemo(() => bulkResults.filter((entry) => entry.error), [bulkResults]);
+
+  const bulkTopEntries = React.useMemo(() => {
+    const aggregated: BulkAnalysisTopEntry[] = [];
+    for (const result of bulkResults) {
+      if (!result.analysis?.entries?.length) continue;
+      for (const entry of result.analysis.entries) {
+        aggregated.push({
+          collectionTag: result.collection.tag,
+          collectionName: result.collection.name,
+          entry,
+        });
+      }
+    }
+
+    aggregated.sort((a, b) => {
+      if (b.entry.ratioPercent !== a.entry.ratioPercent) {
+        return b.entry.ratioPercent - a.entry.ratioPercent;
+      }
+      const profitA = a.entry.profitProbability ?? 0;
+      const profitB = b.entry.profitProbability ?? 0;
+      if (profitB !== profitA) {
+        return profitB - profitA;
+      }
+      return a.entry.targetMarketHashName.localeCompare(b.entry.targetMarketHashName, "ru");
+    });
+
+    return aggregated.slice(0, 15);
+  }, [bulkResults]);
 
   const activeCollection = React.useMemo(
     () => collections.find((collection) => collection.tag === selectedTag) ?? null,
@@ -729,6 +840,28 @@ const CollectionAnalyzer: React.FC = () => {
                 value={filter}
                 onChange={(event) => setFilter(event.target.value)}
               />
+            </div>
+            <div className="collection-analyzer__collections-actions">
+              <button
+                type="button"
+                className="btn btn-outline-light btn-sm"
+                onClick={handleAnalyzeAll}
+                disabled={bulkRunning || !collections.length}
+              >
+                Анализировать все
+              </button>
+              {bulkRunning && bulkProgress ? (
+                <div className="collection-analyzer__bulk-status">
+                  Анализ {Math.min(bulkProgress.completed + 1, bulkProgress.total)} из {bulkProgress.total}
+                  {bulkProgress.currentName ? ` • ${bulkProgress.currentName}` : ""}
+                </div>
+              ) : null}
+              {!bulkRunning && bulkProgress?.total ? (
+                <div className="collection-analyzer__bulk-status">
+                  Проанализировано: {bulkProgress.completed} из {bulkProgress.total}
+                  {bulkErrors.length ? ` • Ошибок: ${bulkErrors.length}` : ""}
+                </div>
+              ) : null}
             </div>
             <div className="collection-analyzer__collections-list">
               {loading && <div className="text-secondary small">Загрузка…</div>}
@@ -856,6 +989,60 @@ const CollectionAnalyzer: React.FC = () => {
             ) : null}
           </div>
         </div>
+        {bulkResults.length ? (
+          <div className="collection-analyzer__bulk-results">
+            <div>
+              <h3 className="h5 mb-1">Результаты массового анализа</h3>
+              <div className="text-secondary small">
+                Коллекций: {bulkResults.length} • Успешно: {bulkResults.length - bulkErrors.length}
+                {bulkErrors.length ? ` • Ошибок: ${bulkErrors.length}` : ""}
+              </div>
+            </div>
+            {bulkTopEntries.length ? (
+              <ul className="collection-analyzer__bulk-list">
+                {bulkTopEntries.map((item) => (
+                  <li key={`${item.collectionTag}:${item.entry.key}`}>
+                    <div className="collection-analyzer__bulk-entry">
+                      <div className="collection-analyzer__bulk-entry-info">
+                        <div className="fw-semibold">{item.collectionName}</div>
+                        <div className="text-secondary small">
+                          {item.entry.targetMarketHashName} • {TARGET_RARITY_TITLES[item.entry.targetRarity]}
+                        </div>
+                      </div>
+                      <div className="collection-analyzer__bulk-metrics">
+                        <span className="collection-analyzer__bulk-metric">
+                          {formatCurrency(item.entry.targetPrice)}
+                        </span>
+                        <span className="collection-analyzer__bulk-metric">
+                          ROI {item.entry.ratioPercent.toFixed(1)}%
+                        </span>
+                        {item.entry.profitProbability != null ? (
+                          <span className="collection-analyzer__bulk-metric">
+                            Профит {formatProbabilityPercent(item.entry.profitProbability)}
+                          </span>
+                        ) : null}
+                      </div>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="text-secondary small">
+                Не удалось подобрать выгодные контракты для выбранных коллекций.
+              </div>
+            )}
+            {bulkErrors.length ? (
+              <div className="text-warning small">
+                Ошибки при обработке: {" "}
+                {bulkErrors
+                  .slice(0, 5)
+                  .map((entry) => entry.collection.name)
+                  .join(", ")}
+                {bulkErrors.length > 5 ? " и другие." : "."}
+              </div>
+            ) : null}
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/server/src/modules/tradeups/service.ts
+++ b/server/src/modules/tradeups/service.ts
@@ -124,6 +124,35 @@ const summarizeTargetsToRanges = (
     .filter((entry): entry is CollectionFloatRange => Boolean(entry));
 };
 
+type OverrideRangeAccumulator = {
+  baseName: string;
+  minFloat: number | null;
+  maxFloat: number | null;
+};
+
+const summarizeOverrideRanges = (
+  overrides: Map<string, OverrideRangeAccumulator>,
+  rarity: TargetRarity,
+): CollectionFloatRange[] => {
+  const fallback = PREDEFINED_FLOATS_BY_RARITY[rarity] ?? new Map();
+  return Array.from(overrides.values())
+    .map((entry) => {
+      let { minFloat, maxFloat } = entry;
+      if (minFloat == null || maxFloat == null) {
+        const predefined = fallback.get(entry.baseName);
+        if (predefined) {
+          minFloat = minFloat == null ? predefined.minFloat : Math.min(minFloat, predefined.minFloat);
+          maxFloat = maxFloat == null ? predefined.maxFloat : Math.max(maxFloat, predefined.maxFloat);
+        }
+      }
+      if (minFloat == null || maxFloat == null) {
+        return null;
+      }
+      return { baseName: entry.baseName, minFloat, maxFloat };
+    })
+    .filter((entry): entry is CollectionFloatRange => Boolean(entry));
+};
+
 const WEAR_BUCKETS: Array<{ exterior: Exterior; min: number; max: number }> = [
   { exterior: "Factory New", min: 0, max: 0.06999999999999999 },
   { exterior: "Minimal Wear", min: 0.07, max: 0.14999999999999999 },
@@ -257,7 +286,7 @@ const buildOutcome = async (
     entry: CollectionFloatRange;
     collectionProbability: number;
     rangeCount: number;
-    override?: TargetOverrideRequest;
+    overridesByCollection: Map<string, TargetOverrideRequest>;
   },
 ): Promise<TradeupOutcome> => {
   const {
@@ -266,20 +295,30 @@ const buildOutcome = async (
     entry,
     collectionProbability,
     rangeCount,
-    override,
+    overridesByCollection,
   } = options;
 
-  const minFloat = override?.minFloat ?? entry.minFloat;
-  const maxFloat = override?.maxFloat ?? entry.maxFloat;
+  const baseKey = `${collection.id}:${entry.baseName.toLowerCase()}`;
+  const baseOverride = overridesByCollection.get(baseKey);
+
+  const minFloat = entry.minFloat;
+  const maxFloat = entry.maxFloat;
   // В игре trade-up использует средний float входов (InputFloat) и линейно
   // преобразует его в диапазон результата: OutputFloat = (Maxout - Minout) * InputFloat + Minout.
   const raw = inputAverageFloat * (maxFloat - minFloat) + minFloat;
   const rollFloat = clamp(raw, minFloat, maxFloat);
-  const exterior = override?.exterior ?? getExteriorByFloat(rollFloat);
+  const defaultExterior = getExteriorByFloat(rollFloat);
+  const baseExterior = baseOverride?.exterior ?? defaultExterior;
+  const baseMarketHashName =
+    baseOverride?.marketHashName ?? toMarketHashName(entry.baseName, baseExterior);
+  const marketKey = `${collection.id}:${baseMarketHashName.toLowerCase()}`;
+  const effectiveOverride = overridesByCollection.get(marketKey) ?? baseOverride;
+  const exterior = effectiveOverride?.exterior ?? baseExterior;
   const wearRange = getWearRange(exterior);
-  const marketHashName = override?.marketHashName ?? toMarketHashName(entry.baseName, exterior);
+  const marketHashName =
+    effectiveOverride?.marketHashName ?? toMarketHashName(entry.baseName, exterior);
 
-  let price = override?.price ?? null;
+  let price = effectiveOverride?.price ?? null;
   let priceError: unknown = undefined;
   if (price == null) {
     const { price: fetchedPrice, error } = await getPriceUSD(marketHashName);
@@ -661,8 +700,9 @@ export const calculateTradeup = async (
     collectionCounts.set(slot.collectionId, (collectionCounts.get(slot.collectionId) ?? 0) + 1);
   }
 
-  const overridesByCollection = new Map<string, TargetOverrideRequest>();
+  const overrideDetails = new Map<string, TargetOverrideRequest>();
   const overrideCollectionTags = new Map<string, string>();
+  const overrideRangesByCollection = new Map<string, Map<string, OverrideRangeAccumulator>>();
   for (const override of payload.targetOverrides ?? []) {
     if (!override?.baseName) continue;
     let collectionId = override.collectionId ?? null;
@@ -674,10 +714,40 @@ export const calculateTradeup = async (
       overrideCollectionTags.set(collectionId, override.collectionTag);
       rememberCollectionId(override.collectionTag, collectionId);
     }
-    const key = `${collectionId}:${override.baseName.toLowerCase()}`;
-    if (!overridesByCollection.has(key)) {
-      overridesByCollection.set(key, { ...override, collectionId });
+    const normalizedOverride: TargetOverrideRequest = { ...override, collectionId };
+    const baseKey = `${collectionId}:${override.baseName.toLowerCase()}`;
+    if (!overrideDetails.has(baseKey)) {
+      overrideDetails.set(baseKey, normalizedOverride);
     }
+    if (override.marketHashName) {
+      const marketKey = `${collectionId}:${override.marketHashName.toLowerCase()}`;
+      overrideDetails.set(marketKey, normalizedOverride);
+    }
+
+    let rangeMap = overrideRangesByCollection.get(collectionId);
+    if (!rangeMap) {
+      rangeMap = new Map<string, OverrideRangeAccumulator>();
+      overrideRangesByCollection.set(collectionId, rangeMap);
+    }
+    const rangeKey = override.baseName.toLowerCase();
+    const current = rangeMap.get(rangeKey) ?? {
+      baseName: override.baseName,
+      minFloat: null,
+      maxFloat: null,
+    };
+    if (typeof override.minFloat === "number") {
+      current.minFloat =
+        current.minFloat == null
+          ? override.minFloat
+          : Math.min(current.minFloat, override.minFloat);
+    }
+    if (typeof override.maxFloat === "number") {
+      current.maxFloat =
+        current.maxFloat == null
+          ? override.maxFloat
+          : Math.max(current.maxFloat, override.maxFloat);
+    }
+    rangeMap.set(rangeKey, current);
   }
 
   const targetRarity: TargetRarity = payload.targetRarity ?? "Covert";
@@ -695,38 +765,25 @@ export const calculateTradeup = async (
       const explicitTag = overrideCollectionTags.get(collection.id);
       const steamTag = explicitTag ?? findSteamTagByCollectionId(collection.id);
       let candidates: CollectionFloatRange[] = [];
+      const overrideRangeMap = overrideRangesByCollection.get(collection.id);
+      if (overrideRangeMap?.size) {
+        candidates = summarizeOverrideRanges(overrideRangeMap, targetRarity);
+      }
       if (steamTag) {
-        try {
-          const result = await fetchCollectionTargets(steamTag, targetRarity);
-          if (result.collectionId) {
-            rememberCollectionId(steamTag, result.collectionId);
+        if (!candidates.length) {
+          try {
+            const result = await fetchCollectionTargets(steamTag, targetRarity);
+            if (result.collectionId) {
+              rememberCollectionId(steamTag, result.collectionId);
+            }
+            candidates = summarizeTargetsToRanges(result.targets, targetRarity);
+          } catch (error) {
+            // Ignore and fall back to catalog
           }
-          candidates = summarizeTargetsToRanges(result.targets, targetRarity);
-        } catch (error) {
-          // Ignore and fall back to catalog
         }
       }
       if (!candidates.length) {
         candidates = getCatalogRangesForRarity(collection, targetRarity);
-      }
-      if (!candidates.length) {
-        const overrideCandidates = Array.from(overridesByCollection.entries())
-          .filter(([key]) => key.startsWith(`${collection.id}:`))
-          .map(([, override]) => {
-            const min = typeof override.minFloat === "number" ? override.minFloat : null;
-            const max = typeof override.maxFloat === "number" ? override.maxFloat : null;
-            if (min != null && max != null) {
-              return { baseName: override.baseName, minFloat: min, maxFloat: max };
-            }
-            const fallback = (PREDEFINED_FLOATS_BY_RARITY[targetRarity] ?? new Map()).get(
-              override.baseName,
-            );
-            return fallback ?? null;
-          })
-          .filter((entry): entry is CollectionFloatRange => Boolean(entry));
-        if (overrideCandidates.length) {
-          candidates = overrideCandidates;
-        }
       }
       return { collection, candidates };
     }),
@@ -746,7 +803,7 @@ export const calculateTradeup = async (
           entry,
           collectionProbability,
           rangeCount,
-          override: overridesByCollection.get(`${collection.id}:${entry.baseName.toLowerCase()}`),
+          overridesByCollection: overrideDetails,
         }),
       );
     }),


### PR DESCRIPTION
## Summary
- add a bulk analysis button that iterates through every collection and shows progress
- surface aggregated results for mass analysis, including top trade-up options and failure details
- update collection analyzer styles to accommodate the new controls and summary

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69092c508ff883329d1584274c686dd7